### PR TITLE
PHPUnit to Pest Converter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,4 +49,4 @@ jobs:
         if: "matrix.php == '8.0'"
 
       - name: Execute PHPUnit
-        run: vendor/bin/phpunit
+        run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,14 @@
 {
     "name": "opis/closure",
     "description": "A library that can be used to serialize closures (anonymous functions) and arbitrary objects.",
-    "keywords": ["closure", "serialization", "function", "serializable", "serialize", "anonymous functions"],
+    "keywords": [
+        "closure",
+        "serialization",
+        "function",
+        "serializable",
+        "serialize",
+        "anonymous functions"
+    ],
     "homepage": "https://opis.io/closure",
     "license": "MIT",
     "authors": [
@@ -19,13 +26,15 @@
     },
     "require-dev": {
         "jeremeamia/superclosure": "^2.0",
-        "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+        "pestphp/pest": "^1.18"
     },
     "autoload": {
         "psr-4": {
             "Opis\\Closure\\": "src/"
         },
-        "files": ["functions.php"]
+        "files": [
+            "functions.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -5,9 +5,6 @@
  * Licensed under the MIT License
  * =========================================================================== */
 
-use Closure;
-use stdClass;
-use Serializable;
 use Opis\Closure\ReflectionClosure;
 use Opis\Closure\SerializableClosure;
 

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -16,7 +16,7 @@ test('closure use return value', function () {
 
     $u = s($c);
 
-    test()->assertEquals($u(), $a);
+    expect($a)->toEqual($u());
 });
 
 test('closure use transformation', function () {
@@ -26,7 +26,7 @@ test('closure use transformation', function () {
         return $a;
     })));
 
-    test()->assertEquals(100, $c());
+    expect($c())->toEqual(100);
 });
 
 test('closure use return closure', function () {
@@ -40,7 +40,7 @@ test('closure use return closure', function () {
     $v = 1;
     $u = s($b);
 
-    test()->assertEquals($v + 1, $u(1));
+    expect($u(1))->toEqual($v + 1);
 });
 
 test('closure use return closure by ref', function () {
@@ -54,7 +54,7 @@ test('closure use return closure by ref', function () {
     $v = 1;
     $u = s($b);
 
-    test()->assertEquals($v + 1, $u(1));
+    expect($u(1))->toEqual($v + 1);
 });
 
 test('closure use self', function () {
@@ -64,7 +64,7 @@ test('closure use self', function () {
     };
     $u = s($a);
 
-    test()->assertEquals($u, $u());
+    expect($u())->toEqual($u);
 });
 
 test('closure use self in array', function () {
@@ -79,7 +79,7 @@ test('closure use self in array', function () {
 
     $u = s($b);
 
-    test()->assertEquals($u, $u());
+    expect($u())->toEqual($u);
 });
 
 test('closure use self in object', function () {
@@ -94,7 +94,7 @@ test('closure use self in object', function () {
 
     $u = s($b);
 
-    test()->assertEquals($u, $u());
+    expect($u())->toEqual($u);
 });
 
 test('closure use self in multi array', function () {
@@ -116,7 +116,7 @@ test('closure use self in multi array', function () {
 
     $u = s($c);
 
-    test()->assertEquals($u, $u(0));
+    expect($u(0))->toEqual($u);
 });
 
 test('closure use self in instance', function () {
@@ -126,7 +126,7 @@ test('closure use self in instance', function () {
     };
     $i->o = $c;
     $u = s($c);
-    test()->assertTrue($u($u));
+    expect($u($u))->toBeTrue();
 });
 
 test('closure use self in instance2', function () {
@@ -136,7 +136,7 @@ test('closure use self in instance2', function () {
     };
     $i->o = &$c;
     $u = s($c);
-    test()->assertTrue($u());
+    expect($u())->toBeTrue();
 });
 
 test('closure serialization twice', function () {
@@ -150,7 +150,7 @@ test('closure serialization twice', function () {
 
     $u = s(s($b));
 
-    test()->assertEquals('ok', $u('ok'));
+    expect($u('ok'))->toEqual('ok');
 });
 
 test('closure real serialization', function () {
@@ -159,7 +159,7 @@ test('closure real serialization', function () {
     };
 
     $u = s(s($f));
-    test()->assertEquals(5, $u(2, 3));
+    expect($u(2, 3))->toEqual(5);
 });
 
 test('closure objectin object', function () {
@@ -183,7 +183,7 @@ test('closure objectin object', function () {
     $ok = $x->func == $x->subtest->func;
     $ok = $ok && ($x->subtest->func == $g);
 
-    test()->assertEquals(true, $ok);
+    expect($ok)->toEqual(true);
 });
 
 test('closure nested', function () {
@@ -205,7 +205,7 @@ test('closure nested', function () {
 
     $os = s($o);
 
-    test()->assertEquals(true, $os(true));
+    expect($os(true))->toEqual(true);
 });
 
 test('closure curly syntax', function () {
@@ -215,7 +215,7 @@ test('closure curly syntax', function () {
         return $x->{'a'} + $x->{$b};
     };
     $f = s($f);
-    test()->assertEquals(4, $f());
+    expect($f())->toEqual(4);
 });
 
 test('closure bind to object', function () {
@@ -229,7 +229,7 @@ test('closure bind to object', function () {
 
     $u = s($b);
 
-    test()->assertEquals('public called', $u());
+    expect($u())->toEqual('public called');
 });
 
 test('closure bind to object scope', function () {
@@ -243,7 +243,7 @@ test('closure bind to object scope', function () {
 
     $u = s($b);
 
-    test()->assertEquals('protected called', $u());
+    expect($u())->toEqual('protected called');
 });
 
 test('closure bind to object static scope', function () {
@@ -257,13 +257,13 @@ test('closure bind to object static scope', function () {
 
     $u = s($b);
 
-    test()->assertEquals('static protected called', $u());
+    expect($u())->toEqual('static protected called');
 });
 
 test('closure static', function () {
     $f = static function(){};
     $rc = new ReflectionClosure($f);
-    test()->assertTrue($rc->isStatic());
+    expect($rc->isStatic())->toBeTrue();
 });
 
 test('closure static fail', function () {
@@ -271,21 +271,21 @@ test('closure static fail', function () {
         // This will not work
     function(){};
     $rc = new ReflectionClosure($f);
-    test()->assertFalse($rc->isStatic());
+    expect($rc->isStatic())->toBeFalse();
 });
 
 test('create closure', function () {
     $closure = SerializableClosure::createClosure('$a, $b', 'return $a + $b;');
 
     test()->assertNotNull($closure);
-    test()->assertTrue($closure instanceof Closure);
-    test()->assertEquals(17, $closure(7, 10));
+    expect($closure instanceof Closure)->toBeTrue();
+    expect($closure(7, 10))->toEqual(17);
 
     $closure = s($closure);
 
     test()->assertNotNull($closure);
-    test()->assertTrue($closure instanceof Closure);
-    test()->assertEquals(11, $closure(5, 6));
+    expect($closure instanceof Closure)->toBeTrue();
+    expect($closure(5, 6))->toEqual(11);
 });
 
 test('closure scope remains the same', function () {
@@ -297,17 +297,17 @@ test('closure scope remains the same', function () {
 
     test()->assertNotNull($rf->getClosureScopeClass());
     test()->assertNotNull($ro->getClosureScopeClass());
-    test()->assertEquals($rf->getClosureScopeClass()->name, $ro->getClosureScopeClass()->name);
-    test()->assertEquals($rf->getClosureScopeClass()->name, $ro->getClosureScopeClass()->name);
-    test()->assertEquals(__CLASS__, $ro->getClosureScopeClass()->name);
+    expect($ro->getClosureScopeClass()->name)->toEqual($rf->getClosureScopeClass()->name);
+    expect($ro->getClosureScopeClass()->name)->toEqual($rf->getClosureScopeClass()->name);
+    expect($ro->getClosureScopeClass()->name)->toEqual(__CLASS__);
 
     $f = $f->bindTo(null, null);
     $o = s($f);
     $rf = new ReflectionClosure($f);
     $ro = new ReflectionClosure($o);
 
-    test()->assertNull($rf->getClosureScopeClass());
-    test()->assertNull($ro->getClosureScopeClass());
+    expect($rf->getClosureScopeClass())->toBeNull();
+    expect($ro->getClosureScopeClass())->toBeNull();
 });
 
 // Helpers

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+/** @link https://pestphp.com/docs/underlying-test-case */
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+/** @link https://pestphp.com/docs/expectations#custom-expectations */
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+/** @link https://pestphp.com/docs/helpers */

--- a/tests/RecursiveArrayTest.php
+++ b/tests/RecursiveArrayTest.php
@@ -5,104 +5,92 @@
  * Licensed under the MIT License
  * =========================================================================== */
 
-namespace Opis\Closure\Test;
-
 use stdClass;
 
-class RecursiveArrayTest extends \PHPUnit\Framework\TestCase
-{
-    public function testRecursiveArray()
-    {
-        $a = ['foo'];
-        $a[] = &$a;
-        $f = function () use($a){
-            return $a[1][0];
-        };
-        $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($f));
-        $this->assertEquals('foo', $u());
-    }
+test('recursive array', function () {
+    $a = ['foo'];
+    $a[] = &$a;
+    $f = function () use($a){
+        return $a[1][0];
+    };
+    $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($f));
+    test()->assertEquals('foo', $u());
+});
 
-    public function testRecursiveArray2()
-    {
-        $a = ['foo'];
-        $a[] = &$a;
-        $f = function () use(&$a){
-            return $a[1][0];
-        };
-        $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($f));
-        $this->assertEquals('foo', $u());
-    }
+test('recursive array2', function () {
+    $a = ['foo'];
+    $a[] = &$a;
+    $f = function () use(&$a){
+        return $a[1][0];
+    };
+    $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($f));
+    test()->assertEquals('foo', $u());
+});
 
-    public function testRecursiveArray3()
-    {
-        $f = function () {
-            return true;
-        };
-        $a = [$f];
-        $a[] = &$a;
+test('recursive array3', function () {
+    $f = function () {
+        return true;
+    };
+    $a = [$f];
+    $a[] = &$a;
 
-        $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
-        $u = $u[1][0];
-        $this->assertTrue($u());
-    }
+    $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
+    $u = $u[1][0];
+    test()->assertTrue($u());
+});
 
-    public function testRecursiveArray4()
-    {
-        $a = [];
-        $f = function () use($a) {
-            return true;
-        };
-        $a[] = $f;
-        $a[] = &$a;
+test('recursive array4', function () {
+    $a = [];
+    $f = function () use($a) {
+        return true;
+    };
+    $a[] = $f;
+    $a[] = &$a;
 
-        $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
-        $u = $u[1][0];
-        $this->assertTrue($u());
-    }
+    $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
+    $u = $u[1][0];
+    test()->assertTrue($u());
+});
 
-    public function testRecursiveArray5()
-    {
-        $a = [];
-        $f = function () use(&$a) {
-            return true;
-        };
-        $a[] = $f;
-        $a[] = &$a;
+test('recursive array5', function () {
+    $a = [];
+    $f = function () use(&$a) {
+        return true;
+    };
+    $a[] = $f;
+    $a[] = &$a;
 
-        $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
-        $u = $u[1][0];
-        $this->assertTrue($u());
-    }
+    $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
+    $u = $u[1][0];
+    test()->assertTrue($u());
+});
 
-    public function testRecursiveArray6()
-    {
-        $o = new stdClass();
-        $o->a = [];
-        $f = function () {
-            return true;
-        };
-        $a = &$o->a;
-        $a[] = $f;
-        $a[] = &$a;
+test('recursive array6', function () {
+    $o = new stdClass();
+    $o->a = [];
+    $f = function () {
+        return true;
+    };
+    $a = &$o->a;
+    $a[] = $f;
+    $a[] = &$a;
 
-        $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($o));
-        $u = $u->a[1][0];
-        $this->assertTrue($u());
-    }
+    $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($o));
+    $u = $u->a[1][0];
+    test()->assertTrue($u());
+});
 
-    public function testRecursiveArray7()
-    {
-        $o = new stdClass();
-        $o->a = [];
-        $f = function () use($o){
-            return true;
-        };
-        $a = &$o->a;
-        $a[] = $f;
-        $a[] = &$a;
+test('recursive array7', function () {
+    $o = new stdClass();
+    $o->a = [];
+    $f = function () use($o){
+        return true;
+    };
+    $a = &$o->a;
+    $a[] = $f;
+    $a[] = &$a;
 
-        $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($o));
-        $u = $u->a[1][0];
-        $this->assertTrue($u());
-    }
-}
+    $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($o));
+    $u = $u->a[1][0];
+    test()->assertTrue($u());
+});

--- a/tests/RecursiveArrayTest.php
+++ b/tests/RecursiveArrayTest.php
@@ -5,7 +5,6 @@
  * Licensed under the MIT License
  * =========================================================================== */
 
-use stdClass;
 
 test('recursive array', function () {
     $a = ['foo'];

--- a/tests/RecursiveArrayTest.php
+++ b/tests/RecursiveArrayTest.php
@@ -13,7 +13,7 @@ test('recursive array', function () {
         return $a[1][0];
     };
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($f));
-    test()->assertEquals('foo', $u());
+    expect($u())->toEqual('foo');
 });
 
 test('recursive array2', function () {
@@ -23,7 +23,7 @@ test('recursive array2', function () {
         return $a[1][0];
     };
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($f));
-    test()->assertEquals('foo', $u());
+    expect($u())->toEqual('foo');
 });
 
 test('recursive array3', function () {
@@ -35,7 +35,7 @@ test('recursive array3', function () {
 
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
     $u = $u[1][0];
-    test()->assertTrue($u());
+    expect($u())->toBeTrue();
 });
 
 test('recursive array4', function () {
@@ -48,7 +48,7 @@ test('recursive array4', function () {
 
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
     $u = $u[1][0];
-    test()->assertTrue($u());
+    expect($u())->toBeTrue();
 });
 
 test('recursive array5', function () {
@@ -61,7 +61,7 @@ test('recursive array5', function () {
 
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
     $u = $u[1][0];
-    test()->assertTrue($u());
+    expect($u())->toBeTrue();
 });
 
 test('recursive array6', function () {
@@ -76,7 +76,7 @@ test('recursive array6', function () {
 
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($o));
     $u = $u->a[1][0];
-    test()->assertTrue($u());
+    expect($u())->toBeTrue();
 });
 
 test('recursive array7', function () {
@@ -91,5 +91,5 @@ test('recursive array7', function () {
 
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($o));
     $u = $u->a[1][0];
-    test()->assertTrue($u());
+    expect($u())->toBeTrue();
 });

--- a/tests/ReflectionClosure2Test.php
+++ b/tests/ReflectionClosure2Test.php
@@ -5,7 +5,6 @@
  * Licensed under the MIT License
  * =========================================================================== */
 
-use Closure;
 use Opis\Closure\ReflectionClosure;
 
 // Fake

--- a/tests/ReflectionClosure2Test.php
+++ b/tests/ReflectionClosure2Test.php
@@ -40,14 +40,14 @@ test('resolve arguments', function () {
     $e8 = 'function ($a = [self::VALUE, parent::VALUE]){}';
 
 
-    test()->assertEquals($e1, c($f1));
-    test()->assertEquals($e2, c($f2));
-    test()->assertEquals($e3, c($f3));
-    test()->assertEquals($e4, c($f4));
-    test()->assertEquals($e5, c($f5));
-    test()->assertEquals($e6, c($f6));
-    test()->assertEquals($e7, c($f7));
-    test()->assertEquals($e8, c($f8));
+    expect(c($f1))->toEqual($e1);
+    expect(c($f2))->toEqual($e2);
+    expect(c($f3))->toEqual($e3);
+    expect(c($f4))->toEqual($e4);
+    expect(c($f5))->toEqual($e5);
+    expect(c($f6))->toEqual($e6);
+    expect(c($f7))->toEqual($e7);
+    expect(c($f8))->toEqual($e8);
 });
 
 test('resolve return type', function () {
@@ -78,15 +78,15 @@ test('resolve return type', function () {
     $f9 = function (){ return Relative\CONST_X + 1;};
     $e9 = 'function (){ return \\' . __NAMESPACE__. '\Relative\CONST_X + 1;}';
 
-    test()->assertEquals($e1, c($f1));
-    test()->assertEquals($e2, c($f2));
-    test()->assertEquals($e3, c($f3));
-    test()->assertEquals($e4, c($f4));
-    test()->assertEquals($e5, c($f5));
-    test()->assertEquals($e6, c($f6));
-    test()->assertEquals($e7, c($f7));
-    test()->assertEquals($e8, c($f8));
-    test()->assertEquals($e9, c($f9));
+    expect(c($f1))->toEqual($e1);
+    expect(c($f2))->toEqual($e2);
+    expect(c($f3))->toEqual($e3);
+    expect(c($f4))->toEqual($e4);
+    expect(c($f5))->toEqual($e5);
+    expect(c($f6))->toEqual($e6);
+    expect(c($f7))->toEqual($e7);
+    expect(c($f8))->toEqual($e8);
+    expect(c($f9))->toEqual($e9);
 });
 
 test('closure inside closure', function () {
@@ -97,8 +97,8 @@ test('closure inside closure', function () {
     $f2 = function() { return function (A $a): A { return $a; }; };
     $e2 = 'function() { return function (\Opis\Closure\Test\A $a): \Opis\Closure\Test\A { return $a; }; }';
 
-    test()->assertEquals($e1, c($f1));
-    test()->assertEquals($e2, c($f2));
+    expect(c($f1))->toEqual($e1);
+    expect(c($f2))->toEqual($e2);
 });
 
 test('anonymous inside closure', function () {
@@ -111,9 +111,9 @@ test('anonymous inside closure', function () {
     $f3 = function() { return new class { function x(A $a): B {} }; };
     $e3 = 'function() { return new class { function x(\Opis\Closure\Test\A $a): \Opis\Closure\Test\B {} }; }';
 
-    test()->assertEquals($e1, c($f1));
-    test()->assertEquals($e2, c($f2));
-    test()->assertEquals($e3, c($f3));
+    expect(c($f1))->toEqual($e1);
+    expect(c($f2))->toEqual($e2);
+    expect(c($f3))->toEqual($e3);
 });
 
 test('closure resolve traits names in anonymous classes', function () {
@@ -139,13 +139,13 @@ test('closure resolve traits names in anonymous classes', function () {
     $e7 = 'function () { new class { use \Foo\Bar; }; function a(\Foo\Baz $q): \Foo\Bar '
         . '{ \Foo\f1(); $a = new class extends \Foo\Bar {}; } }';
 
-    test()->assertEquals($e1, c($f1));
-    test()->assertEquals($e2, c($f2));
-    test()->assertEquals($e3, c($f3));
-    test()->assertEquals($e4, c($f4));
-    test()->assertEquals($e5, c($f5));
-    test()->assertEquals($e6, c($f6));
-    test()->assertEquals($e7, c($f7));
+    expect(c($f1))->toEqual($e1);
+    expect(c($f2))->toEqual($e2);
+    expect(c($f3))->toEqual($e3);
+    expect(c($f4))->toEqual($e4);
+    expect(c($f5))->toEqual($e5);
+    expect(c($f6))->toEqual($e6);
+    expect(c($f7))->toEqual($e7);
 });
 
 test('keyword as static method', function () {
@@ -174,18 +174,18 @@ test('keyword as static method', function () {
     $f12 = function() { Bar::use(); };
     $e12 = 'function() { \Foo\Bar::use(); }';
 
-    test()->assertEquals($e1, c($f1));
-    test()->assertEquals($e2, c($f2));
-    test()->assertEquals($e3, c($f3));
-    test()->assertEquals($e4, c($f4));
-    test()->assertEquals($e5, c($f5));
-    test()->assertEquals($e6, c($f6));
-    test()->assertEquals($e7, c($f7));
-    test()->assertEquals($e8, c($f8));
-    test()->assertEquals($e9, c($f9));
-    test()->assertEquals($e10, c($f10));
-    test()->assertEquals($e11, c($f11));
-    test()->assertEquals($e12, c($f12));
+    expect(c($f1))->toEqual($e1);
+    expect(c($f2))->toEqual($e2);
+    expect(c($f3))->toEqual($e3);
+    expect(c($f4))->toEqual($e4);
+    expect(c($f5))->toEqual($e5);
+    expect(c($f6))->toEqual($e6);
+    expect(c($f7))->toEqual($e7);
+    expect(c($f8))->toEqual($e8);
+    expect(c($f9))->toEqual($e9);
+    expect(c($f10))->toEqual($e10);
+    expect(c($f11))->toEqual($e11);
+    expect(c($f12))->toEqual($e12);
 });
 
 test('this inside anonymous class', function () {
@@ -228,10 +228,10 @@ test('this inside anonymous class', function () {
         $self = $this;
     };
 
-    test()->assertFalse((new ReflectionClosure($f1))->isBindingRequired());
-    test()->assertFalse((new ReflectionClosure($f2))->isBindingRequired());
-    test()->assertTrue((new ReflectionClosure($f3))->isBindingRequired());
-    test()->assertTrue((new ReflectionClosure($f4))->isBindingRequired());
+    expect((new ReflectionClosure($f1))->isBindingRequired())->toBeFalse();
+    expect((new ReflectionClosure($f2))->isBindingRequired())->toBeFalse();
+    expect((new ReflectionClosure($f3))->isBindingRequired())->toBeTrue();
+    expect((new ReflectionClosure($f4))->isBindingRequired())->toBeTrue();
 });
 
 test('is scope required', function () {
@@ -259,17 +259,17 @@ test('is scope required', function () {
         };
     };
 
-    test()->assertTrue(r($f1)->isScopeRequired());
-    test()->assertTrue(r($f2)->isScopeRequired());
-    test()->assertTrue(r($f3)->isScopeRequired());
-    test()->assertFalse(r($f4)->isScopeRequired());
-    test()->assertFalse(r($f5)->isScopeRequired());
-    test()->assertFalse(r($f6)->isScopeRequired());
-    test()->assertFalse(r($f7)->isScopeRequired());
-    test()->assertTrue(r($f8)->isScopeRequired());
+    expect(r($f1)->isScopeRequired())->toBeTrue();
+    expect(r($f2)->isScopeRequired())->toBeTrue();
+    expect(r($f3)->isScopeRequired())->toBeTrue();
+    expect(r($f4)->isScopeRequired())->toBeFalse();
+    expect(r($f5)->isScopeRequired())->toBeFalse();
+    expect(r($f6)->isScopeRequired())->toBeFalse();
+    expect(r($f7)->isScopeRequired())->toBeFalse();
+    expect(r($f8)->isScopeRequired())->toBeTrue();
     test()->assertTrue(r($f9)->isScopeRequired(), 'new static()');
-    test()->assertTrue(r($f10)->isScopeRequired());
-    test()->assertFalse(r($f11)->isScopeRequired());
+    expect(r($f10)->isScopeRequired())->toBeTrue();
+    expect(r($f11)->isScopeRequired())->toBeFalse();
 });
 
 // Helpers

--- a/tests/ReflectionClosure2Test.php
+++ b/tests/ReflectionClosure2Test.php
@@ -9,6 +9,7 @@ use Opis\Closure\ReflectionClosure;
 
 // Fake
 use Foo\{Bar, Baz as Qux};
+
 // Dirty CS
 define(Bar::class, Bar::class);
 use function Foo\f1;

--- a/tests/ReflectionClosure2Test.php
+++ b/tests/ReflectionClosure2Test.php
@@ -5,8 +5,6 @@
  * Licensed under the MIT License
  * =========================================================================== */
 
-namespace Opis\Closure\Test;
-
 use Closure;
 use Opis\Closure\ReflectionClosure;
 
@@ -17,280 +15,271 @@ define(Bar::class, Bar::class);
 use function Foo\f1;
 use function Bar\{b1, b2 as b3};
 
-class ReflectionClosure2Test extends \PHPUnit\Framework\TestCase
+test('resolve arguments', function () {
+    $f1 = function (Bar $p){};
+    $e1 = 'function (\Foo\Bar $p){}';
+
+    $f2 = function (Bar\Test $p){};
+    $e2 = 'function (\Foo\Bar\Test $p){}';
+
+    $f3 = function (Qux $p){};
+    $e3 = 'function (\Foo\Baz $p){}';
+
+    $f4 = function (Qux\Test $p){};
+    $e4 = 'function (\Foo\Baz\Test $p){}';
+
+    $f5 = function (array $p, string $x){};
+    $e5 = 'function (array $p, string $x){}';
+
+    $f6 = function ($a = self::VALUE){};
+    $e6 = 'function ($a = self::VALUE){}';
+
+    $f7 = function ($a = parent::VALUE){};
+    $e7 = 'function ($a = parent::VALUE){}';
+
+    $f8 = function ($a = [self::VALUE, parent::VALUE]){};
+    $e8 = 'function ($a = [self::VALUE, parent::VALUE]){}';
+
+
+    test()->assertEquals($e1, c($f1));
+    test()->assertEquals($e2, c($f2));
+    test()->assertEquals($e3, c($f3));
+    test()->assertEquals($e4, c($f4));
+    test()->assertEquals($e5, c($f5));
+    test()->assertEquals($e6, c($f6));
+    test()->assertEquals($e7, c($f7));
+    test()->assertEquals($e8, c($f8));
+});
+
+test('resolve return type', function () {
+    $f1 = function (): Bar{};
+    $e1 = 'function (): \Foo\Bar{}';
+
+    $f2 = function (): Bar\Test{};
+    $e2 = 'function (): \Foo\Bar\Test{}';
+
+    $f3 = function (): Qux{};
+    $e3 = 'function (): \Foo\Baz{}';
+
+    $f4 = function (): Qux\Test{};
+    $e4 = 'function (): \Foo\Baz\Test{}';
+
+    $f5 = function (): \Foo{};
+    $e5 = 'function (): \Foo{}';
+
+    $f6 = function (): Foo{};
+    $e6 = 'function (): \\' . __NAMESPACE__. '\Foo{}';
+
+    $f7 = function (): array{};
+    $e7 = 'function (): array{}';
+
+    $f8 = function (): string{};
+    $e8 = 'function (): string{}';
+
+    $f9 = function (){ return Relative\CONST_X + 1;};
+    $e9 = 'function (){ return \\' . __NAMESPACE__. '\Relative\CONST_X + 1;}';
+
+    test()->assertEquals($e1, c($f1));
+    test()->assertEquals($e2, c($f2));
+    test()->assertEquals($e3, c($f3));
+    test()->assertEquals($e4, c($f4));
+    test()->assertEquals($e5, c($f5));
+    test()->assertEquals($e6, c($f6));
+    test()->assertEquals($e7, c($f7));
+    test()->assertEquals($e8, c($f8));
+    test()->assertEquals($e9, c($f9));
+});
+
+test('closure inside closure', function () {
+    $f1 = function() { return function ($a): A { return $a; }; };
+    $e1 = 'function() { return function ($a): \Opis\Closure\Test\A { return $a; }; }';
+
+
+    $f2 = function() { return function (A $a): A { return $a; }; };
+    $e2 = 'function() { return function (\Opis\Closure\Test\A $a): \Opis\Closure\Test\A { return $a; }; }';
+
+    test()->assertEquals($e1, c($f1));
+    test()->assertEquals($e2, c($f2));
+});
+
+test('anonymous inside closure', function () {
+    $f1 = function() { return new class extends A {}; };
+    $e1 = 'function() { return new class extends \Opis\Closure\Test\A {}; }';
+
+    $f2 = function() { return new class extends A implements B {}; };
+    $e2 = 'function() { return new class extends \Opis\Closure\Test\A implements \Opis\Closure\Test\B {}; }';
+
+    $f3 = function() { return new class { function x(A $a): B {} }; };
+    $e3 = 'function() { return new class { function x(\Opis\Closure\Test\A $a): \Opis\Closure\Test\B {} }; }';
+
+    test()->assertEquals($e1, c($f1));
+    test()->assertEquals($e2, c($f2));
+    test()->assertEquals($e3, c($f3));
+});
+
+test('closure resolve traits names in anonymous classes', function () {
+    $f1 = function () { new class { use Bar; }; };
+    $e1 = 'function () { new class { use \Foo\Bar; }; }';
+
+    $f2 = function () { new class { use Bar\Test; }; };
+    $e2 = 'function () { new class { use \Foo\Bar\Test; }; }';
+
+    $f3 = function () { new class { use Qux; }; };
+    $e3 = 'function () { new class { use \Foo\Baz; }; }';
+
+    $f4 = function () { new class { use Qux\Test; }; };
+    $e4 = 'function () { new class { use \Foo\Baz\Test; }; }';
+
+    $f5 = function () { new class { use \Foo; }; };
+    $e5 = 'function () { new class { use \Foo; }; }';
+
+    $f6 = function () { new class { use Foo; }; };
+    $e6 = 'function () { new class { use \\' . __NAMESPACE__ . '\Foo; }; }';
+
+    $f7 = function () { new class { use Bar; }; function a(Qux $q): Bar { f1(); $a = new class extends Bar {}; } };
+    $e7 = 'function () { new class { use \Foo\Bar; }; function a(\Foo\Baz $q): \Foo\Bar '
+        . '{ \Foo\f1(); $a = new class extends \Foo\Bar {}; } }';
+
+    test()->assertEquals($e1, c($f1));
+    test()->assertEquals($e2, c($f2));
+    test()->assertEquals($e3, c($f3));
+    test()->assertEquals($e4, c($f4));
+    test()->assertEquals($e5, c($f5));
+    test()->assertEquals($e6, c($f6));
+    test()->assertEquals($e7, c($f7));
+});
+
+test('keyword as static method', function () {
+    $f1 = function() { Bar::new(); };
+    $e1 = 'function() { \Foo\Bar::new(); }';
+    $f2 = function() { Bar::__FILE__(); };
+    $e2 = 'function() { \Foo\Bar::__FILE__(); }';
+    $f3 = function() { Bar::__CLASS__(); };
+    $e3 = 'function() { \Foo\Bar::__CLASS__(); }';
+    $f4 = function() { Bar::__DIR__(); };
+    $e4 = 'function() { \Foo\Bar::__DIR__(); }';
+    $f5 = function() { Bar::__FUNCTION__(); };
+    $e5 = 'function() { \Foo\Bar::__FUNCTION__(); }';
+    $f6 = function() { Bar::__METHOD__(); };
+    $e6 = 'function() { \Foo\Bar::__METHOD__(); }';
+    $f7 = function() { Bar::function(); };
+    $e7 = 'function() { \Foo\Bar::function(); }';
+    $f8 = function() { Bar::instanceof(); };
+    $e8 = 'function() { \Foo\Bar::instanceof(); }';
+    $f9 = function() { Bar::__LINE__(); };
+    $e9 = 'function() { \Foo\Bar::__LINE__(); }';
+    $f10 = function() { Bar::__NAMESPACE__(); };
+    $e10 = 'function() { \Foo\Bar::__NAMESPACE__(); }';
+    $f11 = function() { Bar::__TRAIT__(); };
+    $e11 = 'function() { \Foo\Bar::__TRAIT__(); }';
+    $f12 = function() { Bar::use(); };
+    $e12 = 'function() { \Foo\Bar::use(); }';
+
+    test()->assertEquals($e1, c($f1));
+    test()->assertEquals($e2, c($f2));
+    test()->assertEquals($e3, c($f3));
+    test()->assertEquals($e4, c($f4));
+    test()->assertEquals($e5, c($f5));
+    test()->assertEquals($e6, c($f6));
+    test()->assertEquals($e7, c($f7));
+    test()->assertEquals($e8, c($f8));
+    test()->assertEquals($e9, c($f9));
+    test()->assertEquals($e10, c($f10));
+    test()->assertEquals($e11, c($f11));
+    test()->assertEquals($e12, c($f12));
+});
+
+test('this inside anonymous class', function () {
+    $f1 = function() {
+        return new class {
+            function a(){
+                $self = $this;
+            }
+        };
+    };
+
+    $f2 = function () {
+        return new class {
+            function a(){
+                $self = $this;
+                return new class {
+                    function a(){
+                        $self = $this;
+                    }
+                };
+            }
+        };
+    };
+
+    $f3 = function () {
+        $self = $this;
+        return new class {
+            function a(){
+                $self = $this;
+            }
+        };
+    };
+
+    $f4 = function () {
+        return new class {
+            function a(){
+                $self = $this;
+            }
+        };
+        $self = $this;
+    };
+
+    test()->assertFalse((new ReflectionClosure($f1))->isBindingRequired());
+    test()->assertFalse((new ReflectionClosure($f2))->isBindingRequired());
+    test()->assertTrue((new ReflectionClosure($f3))->isBindingRequired());
+    test()->assertTrue((new ReflectionClosure($f4))->isBindingRequired());
+});
+
+test('is scope required', function () {
+    $f1 = function () { static::test();};
+    $f2 = function ($x = self::CONST_X) {};
+    $f3 = function ($x = parent::CONST_X) {};
+    $f4 = function () { static $i = 1;};
+    $f5 = function () {
+        return function() {
+            static $i = 0;
+        };
+    };
+    $f6 = function () {
+        return function() {
+            static::test();
+        };
+    };
+    $f7 = $f5();
+    $f8 = $f6();
+    $f9 = function () { new static(); };
+    $f10 = function () { new self(); };
+    $f11 = function () {
+        $a = static function ($retries) {
+            return 750 * $retries;
+        };
+    };
+
+    test()->assertTrue(r($f1)->isScopeRequired());
+    test()->assertTrue(r($f2)->isScopeRequired());
+    test()->assertTrue(r($f3)->isScopeRequired());
+    test()->assertFalse(r($f4)->isScopeRequired());
+    test()->assertFalse(r($f5)->isScopeRequired());
+    test()->assertFalse(r($f6)->isScopeRequired());
+    test()->assertFalse(r($f7)->isScopeRequired());
+    test()->assertTrue(r($f8)->isScopeRequired());
+    test()->assertTrue(r($f9)->isScopeRequired(), 'new static()');
+    test()->assertTrue(r($f10)->isScopeRequired());
+    test()->assertFalse(r($f11)->isScopeRequired());
+});
+
+// Helpers
+function c(Closure $closure)
 {
-    protected function c(Closure $closure)
-    {
-        $r = new ReflectionClosure($closure);
-        return $r->getCode();
-    }
+    $r = new ReflectionClosure($closure);
+    return $r->getCode();
+}
 
-    protected function r(Closure $closure) {
-        return new ReflectionClosure($closure);
-    }
-
-    public function testResolveArguments()
-    {
-        $f1 = function (Bar $p){};
-        $e1 = 'function (\Foo\Bar $p){}';
-
-        $f2 = function (Bar\Test $p){};
-        $e2 = 'function (\Foo\Bar\Test $p){}';
-
-        $f3 = function (Qux $p){};
-        $e3 = 'function (\Foo\Baz $p){}';
-
-        $f4 = function (Qux\Test $p){};
-        $e4 = 'function (\Foo\Baz\Test $p){}';
-
-        $f5 = function (array $p, string $x){};
-        $e5 = 'function (array $p, string $x){}';
-
-        $f6 = function ($a = self::VALUE){};
-        $e6 = 'function ($a = self::VALUE){}';
-
-        $f7 = function ($a = parent::VALUE){};
-        $e7 = 'function ($a = parent::VALUE){}';
-
-        $f8 = function ($a = [self::VALUE, parent::VALUE]){};
-        $e8 = 'function ($a = [self::VALUE, parent::VALUE]){}';
-
-
-        $this->assertEquals($e1, $this->c($f1));
-        $this->assertEquals($e2, $this->c($f2));
-        $this->assertEquals($e3, $this->c($f3));
-        $this->assertEquals($e4, $this->c($f4));
-        $this->assertEquals($e5, $this->c($f5));
-        $this->assertEquals($e6, $this->c($f6));
-        $this->assertEquals($e7, $this->c($f7));
-        $this->assertEquals($e8, $this->c($f8));
-    }
-
-    public function testResolveReturnType()
-    {
-        $f1 = function (): Bar{};
-        $e1 = 'function (): \Foo\Bar{}';
-
-        $f2 = function (): Bar\Test{};
-        $e2 = 'function (): \Foo\Bar\Test{}';
-
-        $f3 = function (): Qux{};
-        $e3 = 'function (): \Foo\Baz{}';
-
-        $f4 = function (): Qux\Test{};
-        $e4 = 'function (): \Foo\Baz\Test{}';
-
-        $f5 = function (): \Foo{};
-        $e5 = 'function (): \Foo{}';
-
-        $f6 = function (): Foo{};
-        $e6 = 'function (): \\' . __NAMESPACE__. '\Foo{}';
-
-        $f7 = function (): array{};
-        $e7 = 'function (): array{}';
-
-        $f8 = function (): string{};
-        $e8 = 'function (): string{}';
-
-        $f9 = function (){ return Relative\CONST_X + 1;};
-        $e9 = 'function (){ return \\' . __NAMESPACE__. '\Relative\CONST_X + 1;}';
-
-        $this->assertEquals($e1, $this->c($f1));
-        $this->assertEquals($e2, $this->c($f2));
-        $this->assertEquals($e3, $this->c($f3));
-        $this->assertEquals($e4, $this->c($f4));
-        $this->assertEquals($e5, $this->c($f5));
-        $this->assertEquals($e6, $this->c($f6));
-        $this->assertEquals($e7, $this->c($f7));
-        $this->assertEquals($e8, $this->c($f8));
-        $this->assertEquals($e9, $this->c($f9));
-    }
-
-    public function testClosureInsideClosure()
-    {
-        $f1 = function() { return function ($a): A { return $a; }; };
-        $e1 = 'function() { return function ($a): \Opis\Closure\Test\A { return $a; }; }';
-
-
-        $f2 = function() { return function (A $a): A { return $a; }; };
-        $e2 = 'function() { return function (\Opis\Closure\Test\A $a): \Opis\Closure\Test\A { return $a; }; }';
-
-        $this->assertEquals($e1, $this->c($f1));
-        $this->assertEquals($e2, $this->c($f2));
-    }
-
-    public function testAnonymousInsideClosure()
-    {
-        $f1 = function() { return new class extends A {}; };
-        $e1 = 'function() { return new class extends \Opis\Closure\Test\A {}; }';
-
-        $f2 = function() { return new class extends A implements B {}; };
-        $e2 = 'function() { return new class extends \Opis\Closure\Test\A implements \Opis\Closure\Test\B {}; }';
-
-        $f3 = function() { return new class { function x(A $a): B {} }; };
-        $e3 = 'function() { return new class { function x(\Opis\Closure\Test\A $a): \Opis\Closure\Test\B {} }; }';
-
-        $this->assertEquals($e1, $this->c($f1));
-        $this->assertEquals($e2, $this->c($f2));
-        $this->assertEquals($e3, $this->c($f3));
-    }
-
-    public function testClosureResolveTraitsNamesInAnonymousClasses()
-    {
-        $f1 = function () { new class { use Bar; }; };
-        $e1 = 'function () { new class { use \Foo\Bar; }; }';
-
-        $f2 = function () { new class { use Bar\Test; }; };
-        $e2 = 'function () { new class { use \Foo\Bar\Test; }; }';
-
-        $f3 = function () { new class { use Qux; }; };
-        $e3 = 'function () { new class { use \Foo\Baz; }; }';
-
-        $f4 = function () { new class { use Qux\Test; }; };
-        $e4 = 'function () { new class { use \Foo\Baz\Test; }; }';
-
-        $f5 = function () { new class { use \Foo; }; };
-        $e5 = 'function () { new class { use \Foo; }; }';
-
-        $f6 = function () { new class { use Foo; }; };
-        $e6 = 'function () { new class { use \\' . __NAMESPACE__ . '\Foo; }; }';
-
-        $f7 = function () { new class { use Bar; }; function a(Qux $q): Bar { f1(); $a = new class extends Bar {}; } };
-        $e7 = 'function () { new class { use \Foo\Bar; }; function a(\Foo\Baz $q): \Foo\Bar '
-            . '{ \Foo\f1(); $a = new class extends \Foo\Bar {}; } }';
-
-        $this->assertEquals($e1, $this->c($f1));
-        $this->assertEquals($e2, $this->c($f2));
-        $this->assertEquals($e3, $this->c($f3));
-        $this->assertEquals($e4, $this->c($f4));
-        $this->assertEquals($e5, $this->c($f5));
-        $this->assertEquals($e6, $this->c($f6));
-        $this->assertEquals($e7, $this->c($f7));
-    }
-
-    public function testKeywordAsStaticMethod()
-    {
-        $f1 = function() { Bar::new(); };
-        $e1 = 'function() { \Foo\Bar::new(); }';
-        $f2 = function() { Bar::__FILE__(); };
-        $e2 = 'function() { \Foo\Bar::__FILE__(); }';
-        $f3 = function() { Bar::__CLASS__(); };
-        $e3 = 'function() { \Foo\Bar::__CLASS__(); }';
-        $f4 = function() { Bar::__DIR__(); };
-        $e4 = 'function() { \Foo\Bar::__DIR__(); }';
-        $f5 = function() { Bar::__FUNCTION__(); };
-        $e5 = 'function() { \Foo\Bar::__FUNCTION__(); }';
-        $f6 = function() { Bar::__METHOD__(); };
-        $e6 = 'function() { \Foo\Bar::__METHOD__(); }';
-        $f7 = function() { Bar::function(); };
-        $e7 = 'function() { \Foo\Bar::function(); }';
-        $f8 = function() { Bar::instanceof(); };
-        $e8 = 'function() { \Foo\Bar::instanceof(); }';
-        $f9 = function() { Bar::__LINE__(); };
-        $e9 = 'function() { \Foo\Bar::__LINE__(); }';
-        $f10 = function() { Bar::__NAMESPACE__(); };
-        $e10 = 'function() { \Foo\Bar::__NAMESPACE__(); }';
-        $f11 = function() { Bar::__TRAIT__(); };
-        $e11 = 'function() { \Foo\Bar::__TRAIT__(); }';
-        $f12 = function() { Bar::use(); };
-        $e12 = 'function() { \Foo\Bar::use(); }';
-
-        $this->assertEquals($e1, $this->c($f1));
-        $this->assertEquals($e2, $this->c($f2));
-        $this->assertEquals($e3, $this->c($f3));
-        $this->assertEquals($e4, $this->c($f4));
-        $this->assertEquals($e5, $this->c($f5));
-        $this->assertEquals($e6, $this->c($f6));
-        $this->assertEquals($e7, $this->c($f7));
-        $this->assertEquals($e8, $this->c($f8));
-        $this->assertEquals($e9, $this->c($f9));
-        $this->assertEquals($e10, $this->c($f10));
-        $this->assertEquals($e11, $this->c($f11));
-        $this->assertEquals($e12, $this->c($f12));
-    }
-
-    public function testThisInsideAnonymousClass()
-    {
-        $f1 = function() {
-            return new class {
-                function a(){
-                    $self = $this;
-                }
-            };
-        };
-
-        $f2 = function () {
-            return new class {
-                function a(){
-                    $self = $this;
-                    return new class {
-                        function a(){
-                            $self = $this;
-                        }
-                    };
-                }
-            };
-        };
-
-        $f3 = function () {
-            $self = $this;
-            return new class {
-                function a(){
-                    $self = $this;
-                }
-            };
-        };
-
-        $f4 = function () {
-            return new class {
-                function a(){
-                    $self = $this;
-                }
-            };
-            $self = $this;
-        };
-
-        $this->assertFalse((new ReflectionClosure($f1))->isBindingRequired());
-        $this->assertFalse((new ReflectionClosure($f2))->isBindingRequired());
-        $this->assertTrue((new ReflectionClosure($f3))->isBindingRequired());
-        $this->assertTrue((new ReflectionClosure($f4))->isBindingRequired());
-    }
-
-    public function testIsScopeRequired() {
-        $f1 = function () { static::test();};
-        $f2 = function ($x = self::CONST_X) {};
-        $f3 = function ($x = parent::CONST_X) {};
-        $f4 = function () { static $i = 1;};
-        $f5 = function () {
-            return function() {
-                static $i = 0;
-            };
-        };
-        $f6 = function () {
-            return function() {
-                static::test();
-            };
-        };
-        $f7 = $f5();
-        $f8 = $f6();
-        $f9 = function () { new static(); };
-        $f10 = function () { new self(); };
-        $f11 = function () {
-            $a = static function ($retries) {
-                return 750 * $retries;
-            };
-        };
-
-        $this->assertTrue($this->r($f1)->isScopeRequired());
-        $this->assertTrue($this->r($f2)->isScopeRequired());
-        $this->assertTrue($this->r($f3)->isScopeRequired());
-        $this->assertFalse($this->r($f4)->isScopeRequired());
-        $this->assertFalse($this->r($f5)->isScopeRequired());
-        $this->assertFalse($this->r($f6)->isScopeRequired());
-        $this->assertFalse($this->r($f7)->isScopeRequired());
-        $this->assertTrue($this->r($f8)->isScopeRequired());
-        $this->assertTrue($this->r($f9)->isScopeRequired(), 'new static()');
-        $this->assertTrue($this->r($f10)->isScopeRequired());
-        $this->assertFalse($this->r($f11)->isScopeRequired());
-    }
+function r(Closure $closure) {
+    return new ReflectionClosure($closure);
 }

--- a/tests/ReflectionClosure3Test.php
+++ b/tests/ReflectionClosure3Test.php
@@ -5,7 +5,6 @@
  * Licensed under the MIT License
  * =========================================================================== */
 
-use Closure;
 use Opis\Closure\ReflectionClosure;
 
 // Fake

--- a/tests/ReflectionClosure3Test.php
+++ b/tests/ReflectionClosure3Test.php
@@ -5,8 +5,6 @@
  * Licensed under the MIT License
  * =========================================================================== */
 
-namespace Opis\Closure\Test;
-
 use Closure;
 use Opis\Closure\ReflectionClosure;
 
@@ -15,76 +13,72 @@ use Foo\{Bar, Baz as Qux};
 use function Foo\f1;
 use function Bar\{b1, b2 as b3};
 
-class ReflectionClosure3Test extends \PHPUnit\Framework\TestCase
+test('resolve arguments', function () {
+    $f1 = function (?Bar $p){};
+    $e1 = 'function (?\Foo\Bar $p){}';
+
+    $f2 = function (?Bar\Test $p){};
+    $e2 = 'function (?\Foo\Bar\Test $p){}';
+
+    $f3 = function (?Qux $p){};
+    $e3 = 'function (?\Foo\Baz $p){}';
+
+    $f4 = function (?Qux\Test $p){};
+    $e4 = 'function (?\Foo\Baz\Test $p){}';
+
+    $f5 = function (?array $p, ?string $x){};
+    $e5 = 'function (?array $p, ?string $x){}';
+
+
+    test()->assertEquals($e1, c($f1));
+    test()->assertEquals($e2, c($f2));
+    test()->assertEquals($e3, c($f3));
+    test()->assertEquals($e4, c($f4));
+    test()->assertEquals($e5, c($f5));
+});
+
+test('resolve return type', function () {
+    $f1 = function (): ?Bar{};
+    $e1 = 'function (): ?\Foo\Bar{}';
+
+    $f2 = function (): ?Bar\Test{};
+    $e2 = 'function (): ?\Foo\Bar\Test{}';
+
+    $f3 = function (): ?Qux{};
+    $e3 = 'function (): ?\Foo\Baz{}';
+
+    $f4 = function (): ?Qux\Test{};
+    $e4 = 'function (): ?\Foo\Baz\Test{}';
+
+    $f5 = function (): ?\Foo{};
+    $e5 = 'function (): ?\Foo{}';
+
+    $f6 = function (): ?Foo{};
+    $e6 = 'function (): ?\\' . __NAMESPACE__. '\Foo{}';
+
+    $f7 = function (): ?array{};
+    $e7 = 'function (): ?array{}';
+
+    $f8 = function (): ?string{};
+    $e8 = 'function (): ?string{}';
+
+    $f9 = function (): void{};
+    $e9 = 'function (): void{}';
+
+    test()->assertEquals($e1, c($f1));
+    test()->assertEquals($e2, c($f2));
+    test()->assertEquals($e3, c($f3));
+    test()->assertEquals($e4, c($f4));
+    test()->assertEquals($e5, c($f5));
+    test()->assertEquals($e6, c($f6));
+    test()->assertEquals($e7, c($f7));
+    test()->assertEquals($e8, c($f8));
+    test()->assertEquals($e9, c($f9));
+});
+
+// Helpers
+function c(Closure $closure)
 {
-    protected function c(Closure $closure)
-    {
-        $r = new ReflectionClosure($closure);
-        return $r->getCode();
-    }
-
-    public function testResolveArguments()
-    {
-        $f1 = function (?Bar $p){};
-        $e1 = 'function (?\Foo\Bar $p){}';
-
-        $f2 = function (?Bar\Test $p){};
-        $e2 = 'function (?\Foo\Bar\Test $p){}';
-
-        $f3 = function (?Qux $p){};
-        $e3 = 'function (?\Foo\Baz $p){}';
-
-        $f4 = function (?Qux\Test $p){};
-        $e4 = 'function (?\Foo\Baz\Test $p){}';
-
-        $f5 = function (?array $p, ?string $x){};
-        $e5 = 'function (?array $p, ?string $x){}';
-
-
-        $this->assertEquals($e1, $this->c($f1));
-        $this->assertEquals($e2, $this->c($f2));
-        $this->assertEquals($e3, $this->c($f3));
-        $this->assertEquals($e4, $this->c($f4));
-        $this->assertEquals($e5, $this->c($f5));
-    }
-
-    public function testResolveReturnType()
-    {
-        $f1 = function (): ?Bar{};
-        $e1 = 'function (): ?\Foo\Bar{}';
-
-        $f2 = function (): ?Bar\Test{};
-        $e2 = 'function (): ?\Foo\Bar\Test{}';
-
-        $f3 = function (): ?Qux{};
-        $e3 = 'function (): ?\Foo\Baz{}';
-
-        $f4 = function (): ?Qux\Test{};
-        $e4 = 'function (): ?\Foo\Baz\Test{}';
-
-        $f5 = function (): ?\Foo{};
-        $e5 = 'function (): ?\Foo{}';
-
-        $f6 = function (): ?Foo{};
-        $e6 = 'function (): ?\\' . __NAMESPACE__. '\Foo{}';
-
-        $f7 = function (): ?array{};
-        $e7 = 'function (): ?array{}';
-
-        $f8 = function (): ?string{};
-        $e8 = 'function (): ?string{}';
-
-        $f9 = function (): void{};
-        $e9 = 'function (): void{}';
-
-        $this->assertEquals($e1, $this->c($f1));
-        $this->assertEquals($e2, $this->c($f2));
-        $this->assertEquals($e3, $this->c($f3));
-        $this->assertEquals($e4, $this->c($f4));
-        $this->assertEquals($e5, $this->c($f5));
-        $this->assertEquals($e6, $this->c($f6));
-        $this->assertEquals($e7, $this->c($f7));
-        $this->assertEquals($e8, $this->c($f8));
-        $this->assertEquals($e9, $this->c($f9));
-    }
+    $r = new ReflectionClosure($closure);
+    return $r->getCode();
 }

--- a/tests/ReflectionClosure3Test.php
+++ b/tests/ReflectionClosure3Test.php
@@ -9,7 +9,6 @@ use Opis\Closure\ReflectionClosure;
 
 // Fake
 use Foo\{Bar, Baz as Qux};
-use function Foo\f1;
 use function Bar\{b1, b2 as b3};
 
 test('resolve arguments', function () {

--- a/tests/ReflectionClosure3Test.php
+++ b/tests/ReflectionClosure3Test.php
@@ -29,11 +29,11 @@ test('resolve arguments', function () {
     $e5 = 'function (?array $p, ?string $x){}';
 
 
-    test()->assertEquals($e1, c($f1));
-    test()->assertEquals($e2, c($f2));
-    test()->assertEquals($e3, c($f3));
-    test()->assertEquals($e4, c($f4));
-    test()->assertEquals($e5, c($f5));
+    expect(c($f1))->toEqual($e1);
+    expect(c($f2))->toEqual($e2);
+    expect(c($f3))->toEqual($e3);
+    expect(c($f4))->toEqual($e4);
+    expect(c($f5))->toEqual($e5);
 });
 
 test('resolve return type', function () {
@@ -64,15 +64,15 @@ test('resolve return type', function () {
     $f9 = function (): void{};
     $e9 = 'function (): void{}';
 
-    test()->assertEquals($e1, c($f1));
-    test()->assertEquals($e2, c($f2));
-    test()->assertEquals($e3, c($f3));
-    test()->assertEquals($e4, c($f4));
-    test()->assertEquals($e5, c($f5));
-    test()->assertEquals($e6, c($f6));
-    test()->assertEquals($e7, c($f7));
-    test()->assertEquals($e8, c($f8));
-    test()->assertEquals($e9, c($f9));
+    expect(c($f1))->toEqual($e1);
+    expect(c($f2))->toEqual($e2);
+    expect(c($f3))->toEqual($e3);
+    expect(c($f4))->toEqual($e4);
+    expect(c($f5))->toEqual($e5);
+    expect(c($f6))->toEqual($e6);
+    expect(c($f7))->toEqual($e7);
+    expect(c($f8))->toEqual($e8);
+    expect(c($f9))->toEqual($e9);
 });
 
 // Helpers

--- a/tests/ReflectionClosure4Test.php
+++ b/tests/ReflectionClosure4Test.php
@@ -5,44 +5,37 @@
  * Licensed under the MIT License
  * =========================================================================== */
 
-namespace Opis\Closure\Test;
-
 use Closure;
 use Opis\Closure\ReflectionClosure;
 use Foo\{
     Bar as Baz,
 };
 
-class ReflectionClosure4Test extends \PHPUnit\Framework\TestCase
+test('resolve arguments', function () {
+    $f1 = function (object $p){};
+    $e1 = 'function (object $p){}';
+
+    test()->assertEquals($e1, c($f1));
+});
+
+test('resolve return type', function () {
+    $f1 = function (): object{};
+    $e1 = 'function (): object{}';
+
+
+    test()->assertEquals($e1, c($f1));
+});
+
+test('trailing comma', function () {
+    $f1 = function (): Baz {};
+    $e1 = 'function (): \Foo\Bar {}';
+
+    test()->assertEquals($e1, c($f1));
+});
+
+// Helpers
+function c(Closure $closure)
 {
-    protected function c(Closure $closure)
-    {
-        $r = new ReflectionClosure($closure);
-        return $r->getCode();
-    }
-
-    public function testResolveArguments()
-    {
-        $f1 = function (object $p){};
-        $e1 = 'function (object $p){}';
-
-        $this->assertEquals($e1, $this->c($f1));
-    }
-
-    public function testResolveReturnType()
-    {
-        $f1 = function (): object{};
-        $e1 = 'function (): object{}';
-
-
-        $this->assertEquals($e1, $this->c($f1));
-    }
-
-    public function testTrailingComma()
-    {
-        $f1 = function (): Baz {};
-        $e1 = 'function (): \Foo\Bar {}';
-
-        $this->assertEquals($e1, $this->c($f1));
-    }
+    $r = new ReflectionClosure($closure);
+    return $r->getCode();
 }

--- a/tests/ReflectionClosure4Test.php
+++ b/tests/ReflectionClosure4Test.php
@@ -5,7 +5,6 @@
  * Licensed under the MIT License
  * =========================================================================== */
 
-use Closure;
 use Opis\Closure\ReflectionClosure;
 use Foo\{
     Bar as Baz,

--- a/tests/ReflectionClosure4Test.php
+++ b/tests/ReflectionClosure4Test.php
@@ -14,7 +14,7 @@ test('resolve arguments', function () {
     $f1 = function (object $p){};
     $e1 = 'function (object $p){}';
 
-    test()->assertEquals($e1, c($f1));
+    expect(c($f1))->toEqual($e1);
 });
 
 test('resolve return type', function () {
@@ -22,14 +22,14 @@ test('resolve return type', function () {
     $e1 = 'function (): object{}';
 
 
-    test()->assertEquals($e1, c($f1));
+    expect(c($f1))->toEqual($e1);
 });
 
 test('trailing comma', function () {
     $f1 = function (): Baz {};
     $e1 = 'function (): \Foo\Bar {}';
 
-    test()->assertEquals($e1, c($f1));
+    expect(c($f1))->toEqual($e1);
 });
 
 // Helpers

--- a/tests/ReflectionClosure5Test.php
+++ b/tests/ReflectionClosure5Test.php
@@ -5,8 +5,6 @@
  * Licensed under the MIT License
  * =========================================================================== */
 
-namespace Opis\Closure\Test;
-
 use Closure;
 use Opis\Closure\ReflectionClosure;
 use Foo\{
@@ -15,170 +13,153 @@ use Foo\{
 };
 use Opis\Closure\SerializableClosure;
 
-class ReflectionClosure5Test extends \PHPUnit\Framework\TestCase
+test('is short closure', function () {
+    $f1 = fn() => 1;
+    $f2 = static fn() => 1;
+    $f3 = function () { fn() => 1; };
+
+    test()->assertTrue(r($f1)->isShortClosure());
+    test()->assertTrue(r($f2)->isShortClosure());
+    test()->assertFalse(r($f3)->isShortClosure());
+});
+
+test('basic short closure', function () {
+    $f1 = fn() => "hello";
+    $e1 = 'fn() => "hello"';
+
+    $f2 = fn&() => "hello";
+    $e2 = 'fn&() => "hello"';
+
+    $f3 = fn($a) => "hello";
+    $e3 = 'fn($a) => "hello"';
+
+    $f4 = fn(&$a) => "hello";
+    $e4 = 'fn(&$a) => "hello"';
+
+    $f5 = fn(&$a) : string => "hello";
+    $e5 = 'fn(&$a) : string => "hello"';
+
+    test()->assertEquals($e1, c($f1));
+    test()->assertEquals($e2, c($f2));
+    test()->assertEquals($e3, c($f3));
+    test()->assertEquals($e4, c($f4));
+    test()->assertEquals($e5, c($f5));
+});
+
+test('resolve types', function () {
+    $f1 = fn(Baz $a) => "hello";
+    $e1 = 'fn(\Foo\Bar $a) => "hello"';
+
+    $f2 = fn(Baz $a) : Qux => "hello";
+    $e2 = 'fn(\Foo\Bar $a) : \Foo\Baz\Qux => "hello"';
+
+    $f3 = fn(Baz $a) : int => (function (Qux $x) {})();
+    $e3 = 'fn(\Foo\Bar $a) : int => (function (\Foo\Baz\Qux $x) {})()';
+
+    $f4 = fn() => new Qux();
+    $e4 = 'fn() => new \Foo\Baz\Qux()';
+
+    test()->assertEquals($e1, c($f1));
+    test()->assertEquals($e2, c($f2));
+    test()->assertEquals($e3, c($f3));
+    test()->assertEquals($e4, c($f4));
+});
+
+test('class keywords instantiation', function () {
+    test()->assertEquals(
+        'function () { return new self(); }',
+        c(function () { return new self(); })
+    );
+
+    test()->assertEquals(
+        'function () { return new static(); }',
+        c(function () { return new static(); })
+    );
+
+    test()->assertEquals(
+        'function () { return new parent(); }',
+        c(function () { return new parent(); })
+    );
+});
+
+test('function inside expressions and arrays', function () {
+    $f1 = (fn () => 1);
+    $e1 = 'fn () => 1';
+
+    $f2 = [fn () => 1];
+    $e2 = 'fn () => 1';
+
+    $f3 = [fn () => 1, 0];
+    $e3 = 'fn () => 1';
+
+    $f4 = fn () => ($a === true) && (!empty([0,1,]));
+    $e4 = 'fn () => ($a === true) && (!empty([0,1,]))';
+
+    test()->assertEquals($e1, c($f1));
+    test()->assertEquals($e2, c($f2[0]));
+    test()->assertEquals($e3, c($f3[0]));
+    test()->assertEquals($e4, c($f4));
+});
+
+test('serialize', function () {
+    $f1 = fn() => 'hello';
+    $c1 = s($f1);
+
+    $f2 = fn($a, $b) => $a + $b;
+    $c2 = s($f2);
+
+    $a = 4;
+    $f3 = fn(int $b, int $c = 5) : int => ($a + $b) * $c;
+    $c3 = s($f3);
+
+    test()->assertEquals('hello', $c1());
+    test()->assertEquals(7, $c2(4, 3));
+    test()->assertEquals(40, $c3(4));
+    test()->assertEquals(48, $c3(4, 6));
+});
+
+test('typed properties', function () {
+    $user = new User();
+    $s = s(function () use ($user) {
+        return true;
+    });
+    test()->assertTrue($s());
+
+    $user = new User();
+    $product = new Product();
+    $product->name = "PC";
+    $user->setProduct($product);
+
+    $u = s(function () use ($user) {
+        return $user->getProduct()->name;
+    });
+
+    test()->assertEquals('PC', $u());
+});
+
+// Helpers
+function c(Closure $closure)
 {
-    protected function c(Closure $closure)
-    {
-        $r = new ReflectionClosure($closure);
-        return $r->getCode();
-    }
-
-    protected function r(Closure $closure)
-    {
-        return new ReflectionClosure($closure);
-    }
-
-    protected function s(Closure $closure)
-    {
-        return unserialize(serialize(new SerializableClosure($closure)))->getClosure();
-    }
-
-    public function testIsShortClosure()
-    {
-        $f1 = fn() => 1;
-        $f2 = static fn() => 1;
-        $f3 = function () { fn() => 1; };
-
-        $this->assertTrue($this->r($f1)->isShortClosure());
-        $this->assertTrue($this->r($f2)->isShortClosure());
-        $this->assertFalse($this->r($f3)->isShortClosure());
-    }
-
-    public function testBasicShortClosure()
-    {
-        $f1 = fn() => "hello";
-        $e1 = 'fn() => "hello"';
-
-        $f2 = fn&() => "hello";
-        $e2 = 'fn&() => "hello"';
-
-        $f3 = fn($a) => "hello";
-        $e3 = 'fn($a) => "hello"';
-
-        $f4 = fn(&$a) => "hello";
-        $e4 = 'fn(&$a) => "hello"';
-
-        $f5 = fn(&$a) : string => "hello";
-        $e5 = 'fn(&$a) : string => "hello"';
-
-        $this->assertEquals($e1, $this->c($f1));
-        $this->assertEquals($e2, $this->c($f2));
-        $this->assertEquals($e3, $this->c($f3));
-        $this->assertEquals($e4, $this->c($f4));
-        $this->assertEquals($e5, $this->c($f5));
-    }
-
-    public function testResolveTypes()
-    {
-        $f1 = fn(Baz $a) => "hello";
-        $e1 = 'fn(\Foo\Bar $a) => "hello"';
-
-        $f2 = fn(Baz $a) : Qux => "hello";
-        $e2 = 'fn(\Foo\Bar $a) : \Foo\Baz\Qux => "hello"';
-
-        $f3 = fn(Baz $a) : int => (function (Qux $x) {})();
-        $e3 = 'fn(\Foo\Bar $a) : int => (function (\Foo\Baz\Qux $x) {})()';
-
-        $f4 = fn() => new Qux();
-        $e4 = 'fn() => new \Foo\Baz\Qux()';
-
-        $this->assertEquals($e1, $this->c($f1));
-        $this->assertEquals($e2, $this->c($f2));
-        $this->assertEquals($e3, $this->c($f3));
-        $this->assertEquals($e4, $this->c($f4));
-    }
-
-    public function testClassKeywordsInstantiation()
-    {
-        $this->assertEquals(
-            'function () { return new self(); }',
-            $this->c(function () { return new self(); })
-        );
-
-        $this->assertEquals(
-            'function () { return new static(); }',
-            $this->c(function () { return new static(); })
-        );
-
-        $this->assertEquals(
-            'function () { return new parent(); }',
-            $this->c(function () { return new parent(); })
-        );
-    }
-
-    public function testFunctionInsideExpressionsAndArrays()
-    {
-        $f1 = (fn () => 1);
-        $e1 = 'fn () => 1';
-
-        $f2 = [fn () => 1];
-        $e2 = 'fn () => 1';
-
-        $f3 = [fn () => 1, 0];
-        $e3 = 'fn () => 1';
-
-        $f4 = fn () => ($a === true) && (!empty([0,1,]));
-        $e4 = 'fn () => ($a === true) && (!empty([0,1,]))';
-
-        $this->assertEquals($e1, $this->c($f1));
-        $this->assertEquals($e2, $this->c($f2[0]));
-        $this->assertEquals($e3, $this->c($f3[0]));
-        $this->assertEquals($e4, $this->c($f4));
-    }
-
-    public function testSerialize()
-    {
-        $f1 = fn() => 'hello';
-        $c1 = $this->s($f1);
-
-        $f2 = fn($a, $b) => $a + $b;
-        $c2 = $this->s($f2);
-
-        $a = 4;
-        $f3 = fn(int $b, int $c = 5) : int => ($a + $b) * $c;
-        $c3 = $this->s($f3);
-
-        $this->assertEquals('hello', $c1());
-        $this->assertEquals(7, $c2(4, 3));
-        $this->assertEquals(40, $c3(4));
-        $this->assertEquals(48, $c3(4, 6));
-    }
-
-    public function testTypedProperties()
-    {
-        $user = new User();
-        $s = $this->s(function () use ($user) {
-            return true;
-        });
-        $this->assertTrue($s());
-
-        $user = new User();
-        $product = new Product();
-        $product->name = "PC";
-        $user->setProduct($product);
-
-        $u = $this->s(function () use ($user) {
-            return $user->getProduct()->name;
-        });
-
-        $this->assertEquals('PC', $u());
-    }
+    $r = new ReflectionClosure($closure);
+    return $r->getCode();
 }
 
-class Product {
-    public string $name;
+function r(Closure $closure)
+{
+    return new ReflectionClosure($closure);
 }
 
-class User {
-    protected Product $product;
+function s(Closure $closure)
+{
+    return unserialize(serialize(new SerializableClosure($closure)))->getClosure();
+}
 
-    public function getProduct(): Product
-    {
-        return $this->product;
-    }
+function getProduct(): Product
+{
+    return test()->product;
+}
 
-    public function setProduct(Product $product): void
-    {
-        $this->product = $product;
-    }
+function setProduct(Product $product): void
+{
+    test()->product = $product;
 }

--- a/tests/ReflectionClosure5Test.php
+++ b/tests/ReflectionClosure5Test.php
@@ -5,7 +5,6 @@
  * Licensed under the MIT License
  * =========================================================================== */
 
-use Closure;
 use Opis\Closure\ReflectionClosure;
 use Foo\{
     Bar as Baz,

--- a/tests/ReflectionClosure5Test.php
+++ b/tests/ReflectionClosure5Test.php
@@ -17,9 +17,9 @@ test('is short closure', function () {
     $f2 = static fn() => 1;
     $f3 = function () { fn() => 1; };
 
-    test()->assertTrue(r($f1)->isShortClosure());
-    test()->assertTrue(r($f2)->isShortClosure());
-    test()->assertFalse(r($f3)->isShortClosure());
+    expect(r($f1)->isShortClosure())->toBeTrue();
+    expect(r($f2)->isShortClosure())->toBeTrue();
+    expect(r($f3)->isShortClosure())->toBeFalse();
 });
 
 test('basic short closure', function () {
@@ -38,11 +38,11 @@ test('basic short closure', function () {
     $f5 = fn(&$a) : string => "hello";
     $e5 = 'fn(&$a) : string => "hello"';
 
-    test()->assertEquals($e1, c($f1));
-    test()->assertEquals($e2, c($f2));
-    test()->assertEquals($e3, c($f3));
-    test()->assertEquals($e4, c($f4));
-    test()->assertEquals($e5, c($f5));
+    expect(c($f1))->toEqual($e1);
+    expect(c($f2))->toEqual($e2);
+    expect(c($f3))->toEqual($e3);
+    expect(c($f4))->toEqual($e4);
+    expect(c($f5))->toEqual($e5);
 });
 
 test('resolve types', function () {
@@ -58,10 +58,10 @@ test('resolve types', function () {
     $f4 = fn() => new Qux();
     $e4 = 'fn() => new \Foo\Baz\Qux()';
 
-    test()->assertEquals($e1, c($f1));
-    test()->assertEquals($e2, c($f2));
-    test()->assertEquals($e3, c($f3));
-    test()->assertEquals($e4, c($f4));
+    expect(c($f1))->toEqual($e1);
+    expect(c($f2))->toEqual($e2);
+    expect(c($f3))->toEqual($e3);
+    expect(c($f4))->toEqual($e4);
 });
 
 test('class keywords instantiation', function () {
@@ -94,10 +94,10 @@ test('function inside expressions and arrays', function () {
     $f4 = fn () => ($a === true) && (!empty([0,1,]));
     $e4 = 'fn () => ($a === true) && (!empty([0,1,]))';
 
-    test()->assertEquals($e1, c($f1));
-    test()->assertEquals($e2, c($f2[0]));
-    test()->assertEquals($e3, c($f3[0]));
-    test()->assertEquals($e4, c($f4));
+    expect(c($f1))->toEqual($e1);
+    expect(c($f2[0]))->toEqual($e2);
+    expect(c($f3[0]))->toEqual($e3);
+    expect(c($f4))->toEqual($e4);
 });
 
 test('serialize', function () {
@@ -111,10 +111,10 @@ test('serialize', function () {
     $f3 = fn(int $b, int $c = 5) : int => ($a + $b) * $c;
     $c3 = s($f3);
 
-    test()->assertEquals('hello', $c1());
-    test()->assertEquals(7, $c2(4, 3));
-    test()->assertEquals(40, $c3(4));
-    test()->assertEquals(48, $c3(4, 6));
+    expect($c1())->toEqual('hello');
+    expect($c2(4, 3))->toEqual(7);
+    expect($c3(4))->toEqual(40);
+    expect($c3(4, 6))->toEqual(48);
 });
 
 test('typed properties', function () {
@@ -122,7 +122,7 @@ test('typed properties', function () {
     $s = s(function () use ($user) {
         return true;
     });
-    test()->assertTrue($s());
+    expect($s())->toBeTrue();
 
     $user = new User();
     $product = new Product();
@@ -133,7 +133,7 @@ test('typed properties', function () {
         return $user->getProduct()->name;
     });
 
-    test()->assertEquals('PC', $u());
+    expect($u())->toEqual('PC');
 });
 
 // Helpers

--- a/tests/ReflectionClosureTest.php
+++ b/tests/ReflectionClosureTest.php
@@ -5,7 +5,6 @@
  * Licensed under the MIT License
  * =========================================================================== */
 
-use Closure;
 use Opis\Closure\ReflectionClosure;
 
 // Fake

--- a/tests/ReflectionClosureTest.php
+++ b/tests/ReflectionClosureTest.php
@@ -5,8 +5,6 @@
  * Licensed under the MIT License
  * =========================================================================== */
 
-namespace Opis\Closure\Test;
-
 use Closure;
 use Opis\Closure\ReflectionClosure;
 
@@ -14,179 +12,167 @@ use Opis\Closure\ReflectionClosure;
 use Foo\Bar;
 use Foo\Baz as Qux;
 
-class ReflectionClosureTest extends \PHPUnit\Framework\TestCase
+test('new instance', function () {
+    $f = function (){ $c = '\A'; new $c;};
+    $e = 'function (){ $c = \'\A\'; new $c;}';
+    test()->assertEquals($e, c($f));
+});
+
+test('new instance2', function () {
+    $f = function (){ new A; };
+    $e = 'function (){ new \Opis\Closure\Test\A; }';
+    test()->assertEquals($e, c($f));
+
+    $f = function (){ new A\B; };
+    $e = 'function (){ new \Opis\Closure\Test\A\B; }';
+    test()->assertEquals($e, c($f));
+
+    $f = function (){ new \A; };
+    $e = 'function (){ new \A; }';
+    test()->assertEquals($e, c($f));
+
+    $f = function (){ new A(new B, [new C]); };
+    $e = 'function (){ new \Opis\Closure\Test\A(new \Opis\Closure\Test\B, [new \Opis\Closure\Test\C]); }';
+    test()->assertEquals($e, c($f));
+
+    $f = function (){ new self; new static; new parent; };
+    $e = 'function (){ new self; new static; new parent; }';
+    test()->assertEquals($e, c($f));
+});
+
+test('instance of', function () {
+    $f = function (){ $c = null; $b = '\X\y'; v($c instanceof $b);};
+    $e = 'function (){ $c = null; $b = \'\X\y\'; v($c instanceof $b);}';
+    test()->assertEquals($e, c($f));
+});
+
+test('closure resolve arguments', function () {
+    $f1 = function (Bar $p){};
+    $e1 = 'function (\Foo\Bar $p){}';
+
+    $f2 = function (Bar\Test $p){};
+    $e2 = 'function (\Foo\Bar\Test $p){}';
+
+    $f3 = function (Qux $p){};
+    $e3 = 'function (\Foo\Baz $p){}';
+
+    $f4 = function (Qux\Test $p){};
+    $e4 = 'function (\Foo\Baz\Test $p){}';
+
+    $f5 = function (\Foo $p){};
+    $e5 = 'function (\Foo $p){}';
+
+    $f6 = function (Foo $p){};
+    $e6 = 'function (\\' . __NAMESPACE__ . '\Foo $p){}';
+
+    test()->assertEquals($e1, c($f1));
+    test()->assertEquals($e2, c($f2));
+    test()->assertEquals($e3, c($f3));
+    test()->assertEquals($e4, c($f4));
+    test()->assertEquals($e5, c($f5));
+    test()->assertEquals($e6, c($f6));
+});
+
+test('cloure resolve in body', function () {
+    $f1 = function () { return new Bar(); };
+    $e1 = 'function () { return new \Foo\Bar(); }';
+
+    $f2 = function () { return new Bar\Test(); };
+    $e2 = 'function () { return new \Foo\Bar\Test(); }';
+
+    $f3 = function () { return new Qux(); };
+    $e3 = 'function () { return new \Foo\Baz(); }';
+
+    $f4 = function () { return new Qux\Test(); };
+    $e4 = 'function () { return new \Foo\Baz\Test(); }';
+
+    $f5 = function () { return new \Foo(); };
+    $e5 = 'function () { return new \Foo(); }';
+
+    $f6 = function () { return new Foo(); };
+    $e6 = 'function () { return new \\' . __NAMESPACE__ . '\Foo(); }';
+
+
+    test()->assertEquals($e1, c($f1));
+    test()->assertEquals($e2, c($f2));
+    test()->assertEquals($e3, c($f3));
+    test()->assertEquals($e4, c($f4));
+    test()->assertEquals($e5, c($f5));
+    test()->assertEquals($e6, c($f6));
+});
+
+test('closure resolve static method', function () {
+
+    $f1 = function () { return Bar::test(); };
+    $e1 = 'function () { return \Foo\Bar::test(); }';
+
+    $f2 = function () { return Bar\Test::test(); };
+    $e2 = 'function () { return \Foo\Bar\Test::test(); }';
+
+    $f3 = function () { return Qux::test(); };
+    $e3 = 'function () { return \Foo\Baz::test(); }';
+
+    $f4 = function () { return Qux\Test::test(); };
+    $e4 = 'function () { return \Foo\Baz\Test::test(); }';
+
+    $f5 = function () { return \Foo::test(); };
+    $e5 = 'function () { return \Foo::test(); }';
+
+    $f6 = function () { return Foo::test(); };
+    $e6 = 'function () { return \\' . __NAMESPACE__ . '\Foo::test(); }';
+
+
+    test()->assertEquals($e1, c($f1));
+    test()->assertEquals($e2, c($f2));
+    test()->assertEquals($e3, c($f3));
+    test()->assertEquals($e4, c($f4));
+    test()->assertEquals($e5, c($f5));
+    test()->assertEquals($e6, c($f6));
+});
+
+test('static inside closure', function () {
+    $f1 = function() { return static::foo(); };
+    $e1 = 'function() { return static::foo(); }';
+
+    $f2 = function ($a) { return $a instanceof static; };
+    $e2 = 'function ($a) { return $a instanceof static; }';
+
+    test()->assertEquals($e1, c($f1));
+    test()->assertEquals($e2, c($f2));
+});
+
+test('self inside closure', function () {
+    $f1 = function() { return self::foo(); };
+    $e1 = 'function() { return self::foo(); }';
+
+    $f2 = function ($a) { return $a instanceof self; };
+    $e2 = 'function ($a) { return $a instanceof self; }';
+
+    test()->assertEquals($e1, c($f1));
+    test()->assertEquals($e2, c($f2));
+});
+
+test('parent inside closure', function () {
+    $f1 = function() { return parent::foo(); };
+    $e1 = 'function() { return parent::foo(); }';
+
+    $f2 = function ($a) { return $a instanceof parent; };
+    $e2 = 'function ($a) { return $a instanceof parent; }';
+
+    test()->assertEquals($e1, c($f1));
+    test()->assertEquals($e2, c($f2));
+});
+
+test('interpolation1', function () {
+    $f1 = function() { return "${foo}${bar}{$foobar}"; };
+    $e1 = 'function() { return "${foo}${bar}{$foobar}"; }';
+
+    test()->assertEquals($e1, c($f1));
+});
+
+// Helpers
+function c(Closure $closure)
 {
-    protected function c(Closure $closure)
-    {
-        $r = new ReflectionClosure($closure);
-        return $r->getCode();
-    }
-
-    public function testNewInstance()
-    {
-        $f = function (){ $c = '\A'; new $c;};
-        $e = 'function (){ $c = \'\A\'; new $c;}';
-        $this->assertEquals($e, $this->c($f));
-    }
-
-    public function testNewInstance2()
-    {
-        $f = function (){ new A; };
-        $e = 'function (){ new \Opis\Closure\Test\A; }';
-        $this->assertEquals($e, $this->c($f));
-
-        $f = function (){ new A\B; };
-        $e = 'function (){ new \Opis\Closure\Test\A\B; }';
-        $this->assertEquals($e, $this->c($f));
-
-        $f = function (){ new \A; };
-        $e = 'function (){ new \A; }';
-        $this->assertEquals($e, $this->c($f));
-
-        $f = function (){ new A(new B, [new C]); };
-        $e = 'function (){ new \Opis\Closure\Test\A(new \Opis\Closure\Test\B, [new \Opis\Closure\Test\C]); }';
-        $this->assertEquals($e, $this->c($f));
-
-        $f = function (){ new self; new static; new parent; };
-        $e = 'function (){ new self; new static; new parent; }';
-        $this->assertEquals($e, $this->c($f));
-    }
-
-    public function testInstanceOf()
-    {
-        $f = function (){ $c = null; $b = '\X\y'; v($c instanceof $b);};
-        $e = 'function (){ $c = null; $b = \'\X\y\'; v($c instanceof $b);}';
-        $this->assertEquals($e, $this->c($f));
-    }
-
-    public function testClosureResolveArguments()
-    {
-        $f1 = function (Bar $p){};
-        $e1 = 'function (\Foo\Bar $p){}';
-
-        $f2 = function (Bar\Test $p){};
-        $e2 = 'function (\Foo\Bar\Test $p){}';
-
-        $f3 = function (Qux $p){};
-        $e3 = 'function (\Foo\Baz $p){}';
-
-        $f4 = function (Qux\Test $p){};
-        $e4 = 'function (\Foo\Baz\Test $p){}';
-
-        $f5 = function (\Foo $p){};
-        $e5 = 'function (\Foo $p){}';
-
-        $f6 = function (Foo $p){};
-        $e6 = 'function (\\' . __NAMESPACE__ . '\Foo $p){}';
-
-        $this->assertEquals($e1, $this->c($f1));
-        $this->assertEquals($e2, $this->c($f2));
-        $this->assertEquals($e3, $this->c($f3));
-        $this->assertEquals($e4, $this->c($f4));
-        $this->assertEquals($e5, $this->c($f5));
-        $this->assertEquals($e6, $this->c($f6));
-    }
-
-    public function testCloureResolveInBody()
-    {
-        $f1 = function () { return new Bar(); };
-        $e1 = 'function () { return new \Foo\Bar(); }';
-
-        $f2 = function () { return new Bar\Test(); };
-        $e2 = 'function () { return new \Foo\Bar\Test(); }';
-
-        $f3 = function () { return new Qux(); };
-        $e3 = 'function () { return new \Foo\Baz(); }';
-
-        $f4 = function () { return new Qux\Test(); };
-        $e4 = 'function () { return new \Foo\Baz\Test(); }';
-
-        $f5 = function () { return new \Foo(); };
-        $e5 = 'function () { return new \Foo(); }';
-
-        $f6 = function () { return new Foo(); };
-        $e6 = 'function () { return new \\' . __NAMESPACE__ . '\Foo(); }';
-
-
-        $this->assertEquals($e1, $this->c($f1));
-        $this->assertEquals($e2, $this->c($f2));
-        $this->assertEquals($e3, $this->c($f3));
-        $this->assertEquals($e4, $this->c($f4));
-        $this->assertEquals($e5, $this->c($f5));
-        $this->assertEquals($e6, $this->c($f6));
-    }
-
-    public function testClosureResolveStaticMethod()
-    {
-
-        $f1 = function () { return Bar::test(); };
-        $e1 = 'function () { return \Foo\Bar::test(); }';
-
-        $f2 = function () { return Bar\Test::test(); };
-        $e2 = 'function () { return \Foo\Bar\Test::test(); }';
-
-        $f3 = function () { return Qux::test(); };
-        $e3 = 'function () { return \Foo\Baz::test(); }';
-
-        $f4 = function () { return Qux\Test::test(); };
-        $e4 = 'function () { return \Foo\Baz\Test::test(); }';
-
-        $f5 = function () { return \Foo::test(); };
-        $e5 = 'function () { return \Foo::test(); }';
-
-        $f6 = function () { return Foo::test(); };
-        $e6 = 'function () { return \\' . __NAMESPACE__ . '\Foo::test(); }';
-
-
-        $this->assertEquals($e1, $this->c($f1));
-        $this->assertEquals($e2, $this->c($f2));
-        $this->assertEquals($e3, $this->c($f3));
-        $this->assertEquals($e4, $this->c($f4));
-        $this->assertEquals($e5, $this->c($f5));
-        $this->assertEquals($e6, $this->c($f6));
-    }
-
-    public function testStaticInsideClosure()
-    {
-        $f1 = function() { return static::foo(); };
-        $e1 = 'function() { return static::foo(); }';
-
-        $f2 = function ($a) { return $a instanceof static; };
-        $e2 = 'function ($a) { return $a instanceof static; }';
-
-        $this->assertEquals($e1, $this->c($f1));
-        $this->assertEquals($e2, $this->c($f2));
-    }
-
-    public function testSelfInsideClosure()
-    {
-        $f1 = function() { return self::foo(); };
-        $e1 = 'function() { return self::foo(); }';
-
-        $f2 = function ($a) { return $a instanceof self; };
-        $e2 = 'function ($a) { return $a instanceof self; }';
-
-        $this->assertEquals($e1, $this->c($f1));
-        $this->assertEquals($e2, $this->c($f2));
-    }
-
-    public function testParentInsideClosure()
-    {
-        $f1 = function() { return parent::foo(); };
-        $e1 = 'function() { return parent::foo(); }';
-
-        $f2 = function ($a) { return $a instanceof parent; };
-        $e2 = 'function ($a) { return $a instanceof parent; }';
-
-        $this->assertEquals($e1, $this->c($f1));
-        $this->assertEquals($e2, $this->c($f2));
-    }
-
-    public function testInterpolation1()
-    {
-        $f1 = function() { return "${foo}${bar}{$foobar}"; };
-        $e1 = 'function() { return "${foo}${bar}{$foobar}"; }';
-
-        $this->assertEquals($e1, $this->c($f1));
-    }
+    $r = new ReflectionClosure($closure);
+    return $r->getCode();
 }

--- a/tests/ReflectionClosureTest.php
+++ b/tests/ReflectionClosureTest.php
@@ -14,35 +14,35 @@ use Foo\Baz as Qux;
 test('new instance', function () {
     $f = function (){ $c = '\A'; new $c;};
     $e = 'function (){ $c = \'\A\'; new $c;}';
-    test()->assertEquals($e, c($f));
+    expect(c($f))->toEqual($e);
 });
 
 test('new instance2', function () {
     $f = function (){ new A; };
     $e = 'function (){ new \Opis\Closure\Test\A; }';
-    test()->assertEquals($e, c($f));
+    expect(c($f))->toEqual($e);
 
     $f = function (){ new A\B; };
     $e = 'function (){ new \Opis\Closure\Test\A\B; }';
-    test()->assertEquals($e, c($f));
+    expect(c($f))->toEqual($e);
 
     $f = function (){ new \A; };
     $e = 'function (){ new \A; }';
-    test()->assertEquals($e, c($f));
+    expect(c($f))->toEqual($e);
 
     $f = function (){ new A(new B, [new C]); };
     $e = 'function (){ new \Opis\Closure\Test\A(new \Opis\Closure\Test\B, [new \Opis\Closure\Test\C]); }';
-    test()->assertEquals($e, c($f));
+    expect(c($f))->toEqual($e);
 
     $f = function (){ new self; new static; new parent; };
     $e = 'function (){ new self; new static; new parent; }';
-    test()->assertEquals($e, c($f));
+    expect(c($f))->toEqual($e);
 });
 
 test('instance of', function () {
     $f = function (){ $c = null; $b = '\X\y'; v($c instanceof $b);};
     $e = 'function (){ $c = null; $b = \'\X\y\'; v($c instanceof $b);}';
-    test()->assertEquals($e, c($f));
+    expect(c($f))->toEqual($e);
 });
 
 test('closure resolve arguments', function () {
@@ -64,12 +64,12 @@ test('closure resolve arguments', function () {
     $f6 = function (Foo $p){};
     $e6 = 'function (\\' . __NAMESPACE__ . '\Foo $p){}';
 
-    test()->assertEquals($e1, c($f1));
-    test()->assertEquals($e2, c($f2));
-    test()->assertEquals($e3, c($f3));
-    test()->assertEquals($e4, c($f4));
-    test()->assertEquals($e5, c($f5));
-    test()->assertEquals($e6, c($f6));
+    expect(c($f1))->toEqual($e1);
+    expect(c($f2))->toEqual($e2);
+    expect(c($f3))->toEqual($e3);
+    expect(c($f4))->toEqual($e4);
+    expect(c($f5))->toEqual($e5);
+    expect(c($f6))->toEqual($e6);
 });
 
 test('cloure resolve in body', function () {
@@ -92,12 +92,12 @@ test('cloure resolve in body', function () {
     $e6 = 'function () { return new \\' . __NAMESPACE__ . '\Foo(); }';
 
 
-    test()->assertEquals($e1, c($f1));
-    test()->assertEquals($e2, c($f2));
-    test()->assertEquals($e3, c($f3));
-    test()->assertEquals($e4, c($f4));
-    test()->assertEquals($e5, c($f5));
-    test()->assertEquals($e6, c($f6));
+    expect(c($f1))->toEqual($e1);
+    expect(c($f2))->toEqual($e2);
+    expect(c($f3))->toEqual($e3);
+    expect(c($f4))->toEqual($e4);
+    expect(c($f5))->toEqual($e5);
+    expect(c($f6))->toEqual($e6);
 });
 
 test('closure resolve static method', function () {
@@ -121,12 +121,12 @@ test('closure resolve static method', function () {
     $e6 = 'function () { return \\' . __NAMESPACE__ . '\Foo::test(); }';
 
 
-    test()->assertEquals($e1, c($f1));
-    test()->assertEquals($e2, c($f2));
-    test()->assertEquals($e3, c($f3));
-    test()->assertEquals($e4, c($f4));
-    test()->assertEquals($e5, c($f5));
-    test()->assertEquals($e6, c($f6));
+    expect(c($f1))->toEqual($e1);
+    expect(c($f2))->toEqual($e2);
+    expect(c($f3))->toEqual($e3);
+    expect(c($f4))->toEqual($e4);
+    expect(c($f5))->toEqual($e5);
+    expect(c($f6))->toEqual($e6);
 });
 
 test('static inside closure', function () {
@@ -136,8 +136,8 @@ test('static inside closure', function () {
     $f2 = function ($a) { return $a instanceof static; };
     $e2 = 'function ($a) { return $a instanceof static; }';
 
-    test()->assertEquals($e1, c($f1));
-    test()->assertEquals($e2, c($f2));
+    expect(c($f1))->toEqual($e1);
+    expect(c($f2))->toEqual($e2);
 });
 
 test('self inside closure', function () {
@@ -147,8 +147,8 @@ test('self inside closure', function () {
     $f2 = function ($a) { return $a instanceof self; };
     $e2 = 'function ($a) { return $a instanceof self; }';
 
-    test()->assertEquals($e1, c($f1));
-    test()->assertEquals($e2, c($f2));
+    expect(c($f1))->toEqual($e1);
+    expect(c($f2))->toEqual($e2);
 });
 
 test('parent inside closure', function () {
@@ -158,15 +158,15 @@ test('parent inside closure', function () {
     $f2 = function ($a) { return $a instanceof parent; };
     $e2 = 'function ($a) { return $a instanceof parent; }';
 
-    test()->assertEquals($e1, c($f1));
-    test()->assertEquals($e2, c($f2));
+    expect(c($f1))->toEqual($e1);
+    expect(c($f2))->toEqual($e2);
 });
 
 test('interpolation1', function () {
     $f1 = function() { return "${foo}${bar}{$foobar}"; };
     $e1 = 'function() { return "${foo}${bar}{$foobar}"; }';
 
-    test()->assertEquals($e1, c($f1));
+    expect(c($f1))->toEqual($e1);
 });
 
 // Helpers

--- a/tests/SerializeTest.php
+++ b/tests/SerializeTest.php
@@ -6,8 +6,6 @@
  * =========================================================================== */
 
 use Opis\Closure\ReflectionClosure;
-use stdClass;
-use Closure;
 
 test('custom serialization', function () {
     $f =  function ($value){

--- a/tests/SerializeTest.php
+++ b/tests/SerializeTest.php
@@ -14,7 +14,7 @@ test('custom serialization', function () {
 
     $a = new Abc($f);
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
-    test()->assertTrue($u->test(true));
+    expect($u->test(true))->toBeTrue();
 });
 
 test('custom serialization same objects', function () {
@@ -26,19 +26,19 @@ test('custom serialization same objects', function () {
     $a = array($i, $i);
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
 
-    test()->assertTrue($u[0] === $u[1]);
+    expect($u[0] === $u[1])->toBeTrue();
 });
 
 test('custom serialization this object1', function () {
     $a = new A2();
     $a = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
-    test()->assertEquals('Hello, World!', $a->getPhrase());
+    expect($a->getPhrase())->toEqual('Hello, World!');
 });
 
 test('custom serialization this object2', function () {
     $a = new A2();
     $a = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
-    test()->assertTrue($a->getEquality());
+    expect($a->getEquality())->toBeTrue();
 });
 
 test('custom serialization same closures', function () {
@@ -49,7 +49,7 @@ test('custom serialization same closures', function () {
     $i = new Abc($f);
     $a = array($i, $i);
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
-    test()->assertTrue($u[0]->getF() === $u[1]->getF());
+    expect($u[0]->getF() === $u[1]->getF())->toBeTrue();
 });
 
 test('custom serialization same closures2', function () {
@@ -59,13 +59,13 @@ test('custom serialization same closures2', function () {
 
     $a = array(new Abc($f), new Abc($f));
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
-    test()->assertTrue($u[0]->getF() === $u[1]->getF());
+    expect($u[0]->getF() === $u[1]->getF())->toBeTrue();
 });
 
 test('private method clone', function () {
     $a = new Clone1();
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
-    test()->assertEquals(1, $u->value());
+    expect($u->value())->toEqual(1);
 });
 
 test('private method clone2', function () {
@@ -74,7 +74,7 @@ test('private method clone2', function () {
         return $a->value();
     };
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($f));
-    test()->assertEquals(1, $u());
+    expect($u())->toEqual(1);
 });
 
 test('nested objects', function () {
@@ -88,7 +88,7 @@ test('nested objects', function () {
     };
 
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($f));
-    test()->assertTrue($u());
+    expect($u())->toBeTrue();
 });
 
 test('nested objects2', function () {
@@ -100,7 +100,7 @@ test('nested objects2', function () {
         return true;
     };
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($parent))->closure;
-    test()->assertTrue($u());
+    expect($u())->toBeTrue();
 });
 
 test('nested objects3', function () {
@@ -111,7 +111,7 @@ test('nested objects3', function () {
 
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($obj));
     $c = $u->closure;
-    test()->assertTrue($c($u));
+    expect($c($u))->toBeTrue();
 });
 
 test('nested objects4', function () {
@@ -126,7 +126,7 @@ test('nested objects4', function () {
 
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($parent));
     $c = $u->closure;
-    test()->assertTrue($c($u));
+    expect($c($u))->toBeTrue();
 });
 
 test('nested objects5', function () {
@@ -143,7 +143,7 @@ test('nested objects5', function () {
 
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($parent));
     $c = $u->closure;
-    test()->assertTrue($c($u));
+    expect($c($u))->toBeTrue();
 });
 
 test('private property in parent class', function () {
@@ -154,7 +154,7 @@ test('private property in parent class', function () {
     };
 
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($closure));
-    test()->assertSame(['test'], $u());
+    expect($u())->toBe(['test']);
 });
 
 test('internal class1', function () {
@@ -166,7 +166,7 @@ test('internal class1', function () {
     };
 
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($closure));
-    test()->assertEquals('2018-02-23', $u());
+    expect($u())->toEqual('2018-02-23');
 });
 
 test('internal class2', function () {
@@ -178,7 +178,7 @@ test('internal class2', function () {
     };
 
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($closure));
-    test()->assertEquals('2018-02-23', $u());
+    expect($u())->toEqual('2018-02-23');
 });
 
 test('internal class3', function () {
@@ -187,7 +187,7 @@ test('internal class3', function () {
     $instance = (object)['date' => $date];
 
     $u = \Opis\Closure\unserialize(\Opis\Closure\serialize($instance));
-    test()->assertEquals('2018-02-23', $u->date->format('Y-m-d'));
+    expect($u->date->format('Y-m-d'))->toEqual('2018-02-23');
 });
 
 test('object reserialization', function () {
@@ -196,13 +196,13 @@ test('object reserialization', function () {
     $o = \Opis\Closure\unserialize($s1);
     $s2 = \Opis\Closure\serialize($o);
 
-    test()->assertEquals($s1, $s2);
+    expect($s2)->toEqual($s1);
 });
 
 test('is short closure', function () {
     $f = function () { };
 
-    test()->assertFalse((new ReflectionClosure($f))->isShortClosure());
+    expect((new ReflectionClosure($f))->isShortClosure())->toBeFalse();
 });
 
 test('if this is correctly serialized', function () {
@@ -210,7 +210,7 @@ test('if this is correctly serialized', function () {
     $f = $o->create();
     $f = \Opis\Closure\unserialize(\Opis\Closure\serialize($f));
     $f = \Opis\Closure\unserialize(\Opis\Closure\serialize($f));
-    test()->assertEquals(1, $f());
+    expect($f())->toEqual(1);
 });
 
 test('test', function ($value) {

--- a/tests/SignedClosureTest.php
+++ b/tests/SignedClosureTest.php
@@ -5,171 +5,159 @@
  * Licensed under the MIT License
  * =========================================================================== */
 
-namespace Opis\Closure\Test;
-
 use Opis\Closure\SecurityException;
 use Opis\Closure\SerializableClosure;
 
-class SignedClosureTest extends ClosureTest
-{
-    public function testSecureClosureIntegrityFail()
-    {
-        if (method_exists($this, 'expectException')) {
-            $this->expectException('\Opis\Closure\SecurityException');
-        } else {
-            $this->setExpectedException('\Opis\Closure\SecurityException');
-        }
+uses(ClosureTest::class);
 
-        $closure = function(){
-            /*x*/
-        };
-
-        SerializableClosure::setSecretKey('secret');
-
-        $value = serialize(new SerializableClosure($closure));
-        $value = str_replace('*x*', '*y*', $value);
-        unserialize($value);
+test('secure closure integrity fail', function () {
+    if (method_exists($this, 'expectException')) {
+        test()->expectException('\Opis\Closure\SecurityException');
+    } else {
+        test()->setExpectedException('\Opis\Closure\SecurityException');
     }
 
-    public function testJsonSecureClosureIntegrityFail()
-    {
-        if (method_exists($this, 'expectException')) {
-            $this->expectException('\Opis\Closure\SecurityException');
-        } else {
-            $this->setExpectedException('\Opis\Closure\SecurityException');
-        }
+    $closure = function(){
+        /*x*/
+    };
 
-        $closure = function(){
-            /*x*/
-        };
+    SerializableClosure::setSecretKey('secret');
 
-        SerializableClosure::setSecretKey('secret');
+    $value = serialize(new SerializableClosure($closure));
+    $value = str_replace('*x*', '*y*', $value);
+    unserialize($value);
+});
 
-        $value = serialize(new JsonSerializableClosure($closure));
-        $value = str_replace('*x*', '*y*', $value);
-        unserialize($value);
+test('json secure closure integrity fail', function () {
+    if (method_exists($this, 'expectException')) {
+        test()->expectException('\Opis\Closure\SecurityException');
+    } else {
+        test()->setExpectedException('\Opis\Closure\SecurityException');
     }
 
-    public function testUnsecuredClosureWithSecurityProvider()
-    {
-        if (method_exists($this, 'expectException')) {
-            $this->expectException('\Opis\Closure\SecurityException');
-        } else {
-            $this->setExpectedException('\Opis\Closure\SecurityException');
-        }
+    $closure = function(){
+        /*x*/
+    };
 
-        SerializableClosure::removeSecurityProvider();
+    SerializableClosure::setSecretKey('secret');
 
-        $closure = function(){
-            /*x*/
-        };
+    $value = serialize(new JsonSerializableClosure($closure));
+    $value = str_replace('*x*', '*y*', $value);
+    unserialize($value);
+});
 
-        $value = serialize(new SerializableClosure($closure));
-        SerializableClosure::setSecretKey('secret');
-        unserialize($value);
+test('unsecured closure with security provider', function () {
+    if (method_exists($this, 'expectException')) {
+        test()->expectException('\Opis\Closure\SecurityException');
+    } else {
+        test()->setExpectedException('\Opis\Closure\SecurityException');
     }
 
-    public function testJsonUnsecuredClosureWithSecurityProvider()
-    {
-        if (method_exists($this, 'expectException')) {
-            $this->expectException('\Opis\Closure\SecurityException');
-        } else {
-            $this->setExpectedException('\Opis\Closure\SecurityException');
-        }
+    SerializableClosure::removeSecurityProvider();
 
-        SerializableClosure::removeSecurityProvider();
+    $closure = function(){
+        /*x*/
+    };
 
-        $closure = function(){
-            /*x*/
-        };
+    $value = serialize(new SerializableClosure($closure));
+    SerializableClosure::setSecretKey('secret');
+    unserialize($value);
+});
 
-        $value = serialize(new JsonSerializableClosure($closure));
-        SerializableClosure::setSecretKey('secret');
-        unserialize($value);
+test('json unsecured closure with security provider', function () {
+    if (method_exists($this, 'expectException')) {
+        test()->expectException('\Opis\Closure\SecurityException');
+    } else {
+        test()->setExpectedException('\Opis\Closure\SecurityException');
     }
 
-    public function testSecuredClosureWithoutSecuriyProvider()
-    {
-        SerializableClosure::setSecretKey('secret');
+    SerializableClosure::removeSecurityProvider();
 
-        $closure = function(){
-            return true;
-        };
+    $closure = function(){
+        /*x*/
+    };
 
-        $value = serialize(new SerializableClosure($closure));
-        SerializableClosure::removeSecurityProvider();
-        $closure = unserialize($value)->getClosure();
-        $this->assertTrue($closure());
+    $value = serialize(new JsonSerializableClosure($closure));
+    SerializableClosure::setSecretKey('secret');
+    unserialize($value);
+});
+
+test('secured closure without securiy provider', function () {
+    SerializableClosure::setSecretKey('secret');
+
+    $closure = function(){
+        return true;
+    };
+
+    $value = serialize(new SerializableClosure($closure));
+    SerializableClosure::removeSecurityProvider();
+    $closure = unserialize($value)->getClosure();
+    test()->assertTrue($closure());
+});
+
+test('json secured closure without securiy provider', function () {
+    SerializableClosure::setSecretKey('secret');
+
+    $closure = function(){
+        return true;
+    };
+
+    $value = serialize(new SerializableClosure($closure));
+    SerializableClosure::removeSecurityProvider();
+    $closure = unserialize($value)->getClosure();
+    test()->assertTrue($closure());
+});
+
+test('invalid secured closure without securiy provider', function () {
+    if (method_exists($this, 'expectException')) {
+        test()->expectException('\Opis\Closure\SecurityException');
+    } else {
+        test()->setExpectedException('\Opis\Closure\SecurityException');
     }
 
-    public function testJsonSecuredClosureWithoutSecuriyProvider()
-    {
-        SerializableClosure::setSecretKey('secret');
+    SerializableClosure::setSecretKey('secret');
+    $closure = function(){
+        /*x*/
+    };
 
-        $closure = function(){
-            return true;
-        };
+    $value = serialize(new SerializableClosure($closure));
+    $value = str_replace('.', ',', $value);
+    SerializableClosure::removeSecurityProvider();
+    unserialize($value);
+});
 
-        $value = serialize(new SerializableClosure($closure));
-        SerializableClosure::removeSecurityProvider();
-        $closure = unserialize($value)->getClosure();
-        $this->assertTrue($closure());
+test('invalid json secured closure without securiy provider', function () {
+    if (method_exists($this, 'expectException')) {
+        test()->expectException('\Opis\Closure\SecurityException');
+    } else {
+        test()->setExpectedException('\Opis\Closure\SecurityException');
     }
 
-    public function testInvalidSecuredClosureWithoutSecuriyProvider()
-    {
-        if (method_exists($this, 'expectException')) {
-            $this->expectException('\Opis\Closure\SecurityException');
-        } else {
-            $this->setExpectedException('\Opis\Closure\SecurityException');
-        }
+    SerializableClosure::setSecretKey('secret');
+    $closure = function(){
+        /*x*/
+    };
 
-        SerializableClosure::setSecretKey('secret');
-        $closure = function(){
-            /*x*/
-        };
+    $value = serialize(new JsonSerializableClosure($closure));
+    $value = str_replace('hash', 'hash1', $value);
+    SerializableClosure::removeSecurityProvider();
+    unserialize($value);
+});
 
-        $value = serialize(new SerializableClosure($closure));
-        $value = str_replace('.', ',', $value);
-        SerializableClosure::removeSecurityProvider();
-        unserialize($value);
-    }
+test('mixed encodings', function () {
+    $a = iconv('utf-8', 'utf-16', "Düsseldorf");
+    $b = utf8_decode("Düsseldorf");
 
-    public function testInvalidJsonSecuredClosureWithoutSecuriyProvider()
-    {
-        if (method_exists($this, 'expectException')) {
-            $this->expectException('\Opis\Closure\SecurityException');
-        } else {
-            $this->setExpectedException('\Opis\Closure\SecurityException');
-        }
+    $closure = function() use($a, $b) {
+        return [$a, $b];
+    };
 
-        SerializableClosure::setSecretKey('secret');
-        $closure = function(){
-            /*x*/
-        };
+    SerializableClosure::setSecretKey('secret');
 
-        $value = serialize(new JsonSerializableClosure($closure));
-        $value = str_replace('hash', 'hash1', $value);
-        SerializableClosure::removeSecurityProvider();
-        unserialize($value);
-    }
+    $value = serialize(new SerializableClosure($closure));
+    $u = unserialize($value)->getClosure();
+    $r = $u();
 
-    public function testMixedEncodings()
-    {
-        $a = iconv('utf-8', 'utf-16', "Düsseldorf");
-        $b = utf8_decode("Düsseldorf");
-
-        $closure = function() use($a, $b) {
-            return [$a, $b];
-        };
-
-        SerializableClosure::setSecretKey('secret');
-
-        $value = serialize(new SerializableClosure($closure));
-        $u = unserialize($value)->getClosure();
-        $r = $u();
-
-        $this->assertEquals($a, $r[0]);
-        $this->assertEquals($b, $r[1]);
-    }
-}
+    test()->assertEquals($a, $r[0]);
+    test()->assertEquals($b, $r[1]);
+});

--- a/tests/SignedClosureTest.php
+++ b/tests/SignedClosureTest.php
@@ -5,7 +5,6 @@
  * Licensed under the MIT License
  * =========================================================================== */
 
-use Opis\Closure\SecurityException;
 use Opis\Closure\SerializableClosure;
 
 uses(ClosureTest::class);

--- a/tests/SignedClosureTest.php
+++ b/tests/SignedClosureTest.php
@@ -92,7 +92,7 @@ test('secured closure without securiy provider', function () {
     $value = serialize(new SerializableClosure($closure));
     SerializableClosure::removeSecurityProvider();
     $closure = unserialize($value)->getClosure();
-    test()->assertTrue($closure());
+    expect($closure())->toBeTrue();
 });
 
 test('json secured closure without securiy provider', function () {
@@ -105,7 +105,7 @@ test('json secured closure without securiy provider', function () {
     $value = serialize(new SerializableClosure($closure));
     SerializableClosure::removeSecurityProvider();
     $closure = unserialize($value)->getClosure();
-    test()->assertTrue($closure());
+    expect($closure())->toBeTrue();
 });
 
 test('invalid secured closure without securiy provider', function () {
@@ -158,6 +158,6 @@ test('mixed encodings', function () {
     $u = unserialize($value)->getClosure();
     $r = $u();
 
-    test()->assertEquals($a, $r[0]);
-    test()->assertEquals($b, $r[1]);
+    expect($r[0])->toEqual($a);
+    expect($r[1])->toEqual($b);
 });


### PR DESCRIPTION
This pull request contains changes for migrating your test suite from PHPUnit to [Pest](https://pestphp.com/) automated by the [Pest Converter](https://laravelshift.com/phpunit-to-pest-converter).

**Before merging**, you need to:

- Checkout the `shift-49394` branch
- Review **all** of the comments below for additional changes
- Run `composer update` to install Pest with your dependencies
- Run `vendor/bin/pest` to verify the conversion
